### PR TITLE
fix: prevent host panic on unhashable Go map keys

### DIFF
--- a/convert/common.go
+++ b/convert/common.go
@@ -9,9 +9,11 @@ import (
 type DoNotCompare [0]func()
 
 var (
-	emptyStr string
-	errType  = reflect.TypeOf((*error)(nil)).Elem()
-	rd       = newRecursionDetector()
+	emptyStr       string
+	errType        = reflect.TypeOf((*error)(nil)).Elem()
+	emptyIfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
+	byteType       = reflect.TypeOf(byte(0))
+	rd             = newRecursionDetector()
 )
 
 func newRecursionDetector() *recursionDetector {

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -311,7 +311,79 @@ func adjustedToValue(val reflect.Value, tagName string) (starlark.Value, error) 
 	return toValue(val, tagName)
 }
 
-// FromDict converts a starlark.Dict to a map[interface{}]interface{}
+// hashableGoValue converts a Starlark value into a Go value whose dynamic
+// type is comparable, so it is safe to use as a Go map key. It matches
+// FromValue except for the types whose natural Go form is not comparable:
+//
+//   - starlark.Tuple becomes a fixed-size [N]interface{} array (elements are
+//     converted recursively), so equal tuples stay equal as map keys;
+//   - starlark.Bytes becomes a fixed-size [N]byte array, which keeps bytes
+//     keys distinct from equal string keys.
+//
+// It returns an error for values with no comparable Go form (e.g. dicts,
+// lists, sets, or custom values that convert to non-comparable Go types);
+// using such a value as a Go map key would otherwise escape as a runtime
+// "hash of unhashable type" panic and kill the host process.
+func hashableGoValue(v starlark.Value) (interface{}, error) {
+	switch v := v.(type) {
+	case starlark.Tuple:
+		arr := reflect.New(reflect.ArrayOf(len(v), emptyIfaceType)).Elem()
+		for i, elem := range v {
+			g, err := hashableGoValue(elem)
+			if err != nil {
+				return nil, err
+			}
+			if g != nil {
+				arr.Index(i).Set(reflect.ValueOf(g))
+			}
+		}
+		return arr.Interface(), nil
+	case starlark.Bytes:
+		arr := reflect.New(reflect.ArrayOf(len(v), byteType)).Elem()
+		reflect.Copy(arr, reflect.ValueOf([]byte(v)))
+		return arr.Interface(), nil
+	}
+	g := FromValue(v)
+	if g == nil {
+		return nil, nil
+	}
+	if !reflect.TypeOf(g).Comparable() {
+		return nil, fmt.Errorf("value of type %s converts to Go type %T which is not hashable", v.Type(), g)
+	}
+	return g, nil
+}
+
+// tryKeyConv converts a Starlark value used as a map key into a
+// reflect.Value suitable for indexing a Go map with key type t. Unlike
+// tryConv, it guarantees the result is usable as a Go map key: for
+// interface key types it routes through hashableGoValue, so tuples become
+// comparable arrays and values with no comparable Go form yield an error
+// instead of a runtime "hash of unhashable type" panic.
+func tryKeyConv(v starlark.Value, t reflect.Type) (reflect.Value, error) {
+	if t.Kind() == reflect.Interface {
+		g, err := hashableGoValue(v)
+		if err != nil {
+			return reflect.Value{}, err
+		}
+		if g == nil {
+			return reflect.Zero(t), nil
+		}
+		out := reflect.ValueOf(g)
+		if t.NumMethod() > 0 && !out.Type().Implements(t) {
+			return reflect.Value{}, fmt.Errorf("value of type %s cannot be converted to type %s", out.Type(), t)
+		}
+		return out, nil
+	}
+	// Non-interface Go map key types are comparable by construction, so the
+	// regular conversion is already safe.
+	return tryConv(v, t)
+}
+
+// FromDict converts a starlark.Dict to a map[interface{}]interface{}.
+// Keys are converted with the same rules as TryFromDict; a key with no
+// comparable Go form falls back to its printed form (k.String()) so the
+// entry is preserved instead of panicking. Use TryFromDict to detect such
+// keys instead of silently accepting the fallback.
 func FromDict(m *starlark.Dict) map[interface{}]interface{} {
 	// return nil to avoid infinite recursion
 	if rd.hasVisited(m) {
@@ -322,13 +394,42 @@ func FromDict(m *starlark.Dict) map[interface{}]interface{} {
 
 	ret := make(map[interface{}]interface{}, m.Len())
 	for _, k := range m.Keys() {
-		key := FromValue(k)
+		key, err := hashableGoValue(k)
+		if err != nil {
+			// no comparable Go form: keep the entry under its printed form
+			// rather than panicking or dropping it silently
+			key = k.String()
+		}
 		// should never be not found or unhashable, so ignore err and found.
 		val, _, _ := m.Get(k)
-		//ret[key] = val
 		ret[key] = FromValue(val)
 	}
 	return ret
+}
+
+// TryFromDict converts a starlark.Dict to a map[interface{}]interface{}.
+// It works like FromDict, but returns an error if any key has no comparable
+// Go form (e.g. a custom value that converts to a non-comparable Go type)
+// instead of falling back to the key's printed form.
+func TryFromDict(m *starlark.Dict) (map[interface{}]interface{}, error) {
+	// return nil to avoid infinite recursion
+	if rd.hasVisited(m) {
+		return nil, nil
+	}
+	rd.setVisited(m)
+	defer rd.clearVisited(m)
+
+	ret := make(map[interface{}]interface{}, m.Len())
+	for _, k := range m.Keys() {
+		key, err := hashableGoValue(k)
+		if err != nil {
+			return nil, fmt.Errorf("dict key %s: %v", k.String(), err)
+		}
+		// should never be not found or unhashable, so ignore err and found.
+		val, _, _ := m.Get(k)
+		ret[key] = FromValue(val)
+	}
+	return ret, nil
 }
 
 // MakeSet makes a Set from the given map. The acceptable keys the same as ToValue.
@@ -363,17 +464,45 @@ func MakeSetFromSlice(s []interface{}) (*starlark.Set, error) {
 	return &set, nil
 }
 
-// FromSet converts a starlark.Set to a map[interface{}]bool
+// FromSet converts a starlark.Set to a map[interface{}]bool.
+// Elements are converted with the same rules as TryFromSet; an element with
+// no comparable Go form falls back to its printed form (v.String()) so the
+// member is preserved instead of panicking. Use TryFromSet to detect such
+// elements instead of silently accepting the fallback.
 func FromSet(s *starlark.Set) map[interface{}]bool {
 	ret := make(map[interface{}]bool, s.Len())
 	var v starlark.Value
 	i := s.Iterate()
 	defer i.Done()
 	for i.Next(&v) {
-		val := FromValue(v)
+		val, err := hashableGoValue(v)
+		if err != nil {
+			// no comparable Go form: keep the member under its printed form
+			// rather than panicking or dropping it silently
+			val = v.String()
+		}
 		ret[val] = true
 	}
 	return ret
+}
+
+// TryFromSet converts a starlark.Set to a map[interface{}]bool.
+// It works like FromSet, but returns an error if any element has no
+// comparable Go form (e.g. a custom value that converts to a non-comparable
+// Go type) instead of falling back to the element's printed form.
+func TryFromSet(s *starlark.Set) (map[interface{}]bool, error) {
+	ret := make(map[interface{}]bool, s.Len())
+	var v starlark.Value
+	i := s.Iterate()
+	defer i.Done()
+	for i.Next(&v) {
+		val, err := hashableGoValue(v)
+		if err != nil {
+			return nil, fmt.Errorf("set element %s: %v", v.String(), err)
+		}
+		ret[val] = true
+	}
+	return ret, nil
 }
 
 // Kwarg is a single instance of a python foo=bar style named argument.

--- a/convert/hashable_test.go
+++ b/convert/hashable_test.go
@@ -1,0 +1,238 @@
+package convert_test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// Regression tests for unhashable dict/set keys: a Starlark value whose Go
+// form is not comparable (e.g. dict, list, set, or a tuple converted to
+// []interface{}) used to escape as a runtime panic ("hash of unhashable
+// type") and kill the host process. These tests pin the graceful behavior:
+// errors for keys with no comparable Go form, and comparable equivalents
+// (fixed-size arrays) for tuples and bytes.
+
+// TestGoMapUnhashableKeyErrors verifies that scripts indexing a wrapped Go
+// map with an unhashable key get a Starlark error instead of a host panic.
+func TestGoMapUnhashableKeyErrors(t *testing.T) {
+	tests := []fail{
+		{`m[{1: 2}] = "x"`, "not hashable"},
+		{`m[[1, 2]] = "x"`, "not hashable"},
+		{`m[set([1])] = "x"`, "not hashable"},
+		{`v = m[{1: 2}]`, "not hashable"},
+		{`m.pop([1, 2])`, "not hashable"},
+		{`m.get({1: 2})`, "not hashable"},
+		{`m.setdefault([1], "x")`, "not hashable"},
+	}
+	for _, f := range tests {
+		t.Run(f.code, func(t *testing.T) {
+			m := map[interface{}]interface{}{"a": "b"}
+			globals := map[string]interface{}{"m": m}
+			_, err := starlight.Eval([]byte(f.code), globals, nil)
+			if err == nil || !strings.Contains(err.Error(), f.err) {
+				t.Fatalf(`expected error containing %q, got %v`, f.err, err)
+			}
+			if len(m) != 1 {
+				t.Errorf("expected map to be unchanged, got %v", m)
+			}
+		})
+	}
+}
+
+// TestGoMapTupleKey verifies that tuple keys work on wrapped Go maps with
+// interface{} keys: they are stored as comparable fixed-size arrays, so
+// writing and reading back with an equal tuple round-trips.
+func TestGoMapTupleKey(t *testing.T) {
+	m := map[interface{}]interface{}{}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+m[(1, "a")] = "x"
+assert.Eq(m[(1, "a")], "x")
+assert.Eq(m.get((1, "a")), "x")
+assert.Eq(len(m), 1)
+v = m.pop((1, "a"))
+assert.Eq(v, "x")
+assert.Eq(len(m), 0)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	// write again and inspect the Go-side key form
+	code = []byte(`m[(1, "a")] = "y"`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	wantKey := [2]interface{}{int64(1), "a"}
+	if got, ok := m[wantKey]; !ok || got != "y" {
+		t.Fatalf("expected m[%#v] == %q, map is %#v", wantKey, "y", m)
+	}
+}
+
+// TestFromDictTupleKey verifies FromDict converts tuple keys to comparable
+// fixed-size arrays instead of panicking on []interface{} map keys.
+func TestFromDictTupleKey(t *testing.T) {
+	d := starlark.NewDict(2)
+	if err := d.SetKey(starlark.Tuple{starlark.String("A"), starlark.MakeInt(1)}, starlark.Bool(true)); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetKey(starlark.Tuple{starlark.String("B"), starlark.MakeInt(2)}, starlark.Bool(false)); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromDict(d)
+	want := map[interface{}]interface{}{
+		[2]interface{}{"A", int64(1)}: true,
+		[2]interface{}{"B", int64(2)}: false,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+	for k, v := range want {
+		if gv, ok := got[k]; !ok || gv != v {
+			t.Fatalf("expected key %#v -> %#v in %#v", k, v, got)
+		}
+	}
+}
+
+// TestFromDictBytesKey verifies bytes keys become fixed-size byte arrays,
+// which are comparable and stay distinct from equal string keys.
+func TestFromDictBytesKey(t *testing.T) {
+	d := starlark.NewDict(2)
+	if err := d.SetKey(starlark.Bytes("ab"), starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetKey(starlark.String("ab"), starlark.MakeInt(2)); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromDict(d)
+	if len(got) != 2 {
+		t.Fatalf("expected bytes and string keys to stay distinct, got %#v", got)
+	}
+	if v, ok := got[[2]byte{'a', 'b'}]; !ok || v != int64(1) {
+		t.Fatalf("expected bytes key [2]byte{'a','b'} -> 1, got %#v", got)
+	}
+	if v, ok := got["ab"]; !ok || v != int64(2) {
+		t.Fatalf(`expected string key "ab" -> 2, got %#v`, got)
+	}
+}
+
+// TestFromSetTupleElem verifies FromSet converts tuple elements to
+// comparable arrays instead of panicking.
+func TestFromSetTupleElem(t *testing.T) {
+	s := starlark.NewSet(2)
+	if err := s.Insert(starlark.Tuple{starlark.MakeInt(1), starlark.String("A")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Insert(starlark.Tuple{starlark.MakeInt(2), starlark.String("B")}); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromSet(s)
+	want := map[interface{}]bool{
+		[2]interface{}{int64(1), "A"}: true,
+		[2]interface{}{int64(2), "B"}: true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+	for k := range want {
+		if !got[k] {
+			t.Fatalf("expected member %#v in %#v", k, got)
+		}
+	}
+}
+
+// customHashableValue is a Starlark value that claims to be hashable on the
+// Starlark side but converts to a non-comparable Go value (itself, holding a
+// slice), to exercise the error paths of TryFromDict / TryFromSet.
+type customHashableValue struct {
+	s []string
+}
+
+func (customHashableValue) String() string        { return "customHashableValue" }
+func (customHashableValue) Type() string          { return "customHashableValue" }
+func (customHashableValue) Freeze()               {}
+func (customHashableValue) Truth() starlark.Bool  { return true }
+func (customHashableValue) Hash() (uint32, error) { return 42, nil }
+func (v customHashableValue) CompareSameType(op syntax.Token, y starlark.Value, depth int) (bool, error) {
+	eq := reflect.DeepEqual(v, y)
+	switch op {
+	case syntax.EQL:
+		return eq, nil
+	case syntax.NEQ:
+		return !eq, nil
+	}
+	return false, fmt.Errorf("unsupported comparison %s", op)
+}
+
+// TestTryFromDict verifies the error-returning variant: clean dicts convert
+// with a nil error, and keys with no comparable Go form yield an error.
+func TestTryFromDict(t *testing.T) {
+	d := starlark.NewDict(2)
+	if err := d.SetKey(starlark.String("a"), starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetKey(starlark.Tuple{starlark.MakeInt(1)}, starlark.MakeInt(2)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := convert.TryFromDict(d)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 2 || got["a"] != int64(1) || got[[1]interface{}{int64(1)}] != int64(2) {
+		t.Fatalf("unexpected conversion result: %#v", got)
+	}
+
+	bad := starlark.NewDict(1)
+	if err := bad.SetKey(customHashableValue{s: []string{"x"}}, starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := convert.TryFromDict(bad); err == nil || !strings.Contains(err.Error(), "hashable") {
+		t.Fatalf("expected unhashable key error, got %v", err)
+	}
+}
+
+// TestTryFromSet mirrors TestTryFromDict for sets.
+func TestTryFromSet(t *testing.T) {
+	s := starlark.NewSet(1)
+	if err := s.Insert(starlark.Tuple{starlark.MakeInt(1)}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := convert.TryFromSet(s)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !got[[1]interface{}{int64(1)}] {
+		t.Fatalf("unexpected conversion result: %#v", got)
+	}
+
+	bad := starlark.NewSet(1)
+	if err := bad.Insert(customHashableValue{s: []string{"x"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := convert.TryFromSet(bad); err == nil || !strings.Contains(err.Error(), "hashable") {
+		t.Fatalf("expected unhashable element error, got %v", err)
+	}
+}
+
+// TestFromDictUnhashableFallback verifies the legacy FromDict keeps entries
+// for keys with no comparable Go form by falling back to their printed form
+// (instead of panicking or dropping data silently).
+func TestFromDictUnhashableFallback(t *testing.T) {
+	d := starlark.NewDict(1)
+	if err := d.SetKey(customHashableValue{s: []string{"x"}}, starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromDict(d)
+	if v, ok := got["customHashableValue"]; !ok || v != int64(1) {
+		t.Fatalf("expected printed-form fallback key, got %#v", got)
+	}
+}

--- a/convert/map.go
+++ b/convert/map.go
@@ -48,7 +48,7 @@ func (g *GoMap) SetKey(k, v starlark.Value) (err error) {
 		return fmt.Errorf("cannot insert into map during iteration")
 	}
 
-	key, err := tryConv(k, g.v.Type().Key())
+	key, err := tryKeyConv(k, g.v.Type().Key())
 	if err != nil {
 		return fmt.Errorf("setkey key: %v", err)
 	}
@@ -64,7 +64,7 @@ func (g *GoMap) SetKey(k, v starlark.Value) (err error) {
 // Get implements starlark.Mapping.
 func (g *GoMap) Get(in starlark.Value) (out starlark.Value, found bool, err error) {
 	//v := g.v.MapIndex(conv(in, g.v.Type().Key()))
-	key, err := tryConv(in, g.v.Type().Key())
+	key, err := tryKeyConv(in, g.v.Type().Key())
 	if err != nil {
 		return nil, false, fmt.Errorf("get: %v", err)
 	}
@@ -139,7 +139,7 @@ func (g *GoMap) Delete(k starlark.Value) (v starlark.Value, found bool, err erro
 	if g.numIt > 0 {
 		return nil, false, fmt.Errorf("cannot delete from map during iteration")
 	}
-	key, err := tryConv(k, g.v.Type().Key())
+	key, err := tryKeyConv(k, g.v.Type().Key())
 	if err != nil {
 		return nil, false, fmt.Errorf("delete: %v", err)
 	}


### PR DESCRIPTION
## Problem

A Starlark value whose Go form is not comparable — a dict, list, set, or a tuple (converted to `[]interface{}`) — used as a key of a wrapped Go map escaped as a runtime `hash of unhashable type` panic and killed the host process. Pure Starlark dicts were unaffected; only the starlight Go-side bridge was.

```python
m[{1: 2}] = "x"   # was: host process dies
m[(1, "a")] = "x" # was: host process dies (tuple -> []interface{} key)
```

The same panic was reachable from the host side via `FromDict`/`FromSet` on dicts/sets with tuple or bytes keys.

## Fix

- `GoMap.SetKey/Get/Delete` now route keys through a new `tryKeyConv`, which returns a regular error for keys with no comparable Go form instead of panicking.
- Tuple keys become fixed-size `[N]interface{}` arrays (recursively), so they work as Go map keys with equality preserved and round-trip from scripts; bytes keys become `[N]byte` arrays and stay distinct from equal string keys.
- `FromDict`/`FromSet` no longer panic: entries whose key has no comparable Go form fall back to the key's printed form (documented), and new `TryFromDict`/`TryFromSet` variants return an error instead for callers that need to detect this.

## Tests

New `convert/hashable_test.go` covers: script-level unhashable-key errors on all GoMap paths (set/get/pop/setdefault), tuple-key round-trip, `FromDict`/`FromSet` tuple and bytes keys, `TryFromDict`/`TryFromSet` success and error paths, and the legacy fallback. Full suite passes with `-race` on Go 1.25, and on Go 1.18/1.19 (Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)