### PR TITLE
fix: make Go map key order deterministic in Starlark

### DIFF
--- a/convert/common.go
+++ b/convert/common.go
@@ -1,7 +1,10 @@
 package convert
 
 import (
+	"fmt"
+	"math"
 	"reflect"
+	"sort"
 	"sync"
 )
 
@@ -15,6 +18,76 @@ var (
 	byteType       = reflect.TypeOf(byte(0))
 	rd             = newRecursionDetector()
 )
+
+// sortedMapKeys returns the keys of the given map value in a deterministic
+// order: keys are sorted by type rank (nil < bool < int < uint < float <
+// string < other), then by value within the same rank; "other" keys compare
+// by their printed form. reflect's MapKeys returns keys in Go's randomized
+// map iteration order, which would otherwise leak into Starlark everywhere
+// a wrapped Go map is materialized (keys/items/values/iteration/popitem and
+// MakeDict) and make script output non-reproducible across runs.
+func sortedMapKeys(m reflect.Value) []reflect.Value {
+	keys := m.MapKeys()
+	sort.SliceStable(keys, func(i, j int) bool { return keyLess(keys[i], keys[j]) })
+	return keys
+}
+
+// keyRank classifies a map key for sorting: it unwraps interface keys to
+// their dynamic value and returns the type rank along with the unwrapped
+// value used for same-rank comparison.
+func keyRank(v reflect.Value) (int, reflect.Value) {
+	if v.Kind() == reflect.Interface {
+		if v.IsNil() {
+			return 0, v
+		}
+		v = v.Elem()
+	}
+	switch v.Kind() {
+	case reflect.Bool:
+		return 1, v
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return 2, v
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return 3, v
+	case reflect.Float32, reflect.Float64:
+		return 4, v
+	case reflect.String:
+		return 5, v
+	}
+	return 6, v
+}
+
+// keyLess is the strict weak ordering used by sortedMapKeys.
+func keyLess(a, b reflect.Value) bool {
+	ra, va := keyRank(a)
+	rb, vb := keyRank(b)
+	if ra != rb {
+		return ra < rb
+	}
+	switch ra {
+	case 1:
+		return !va.Bool() && vb.Bool()
+	case 2:
+		return va.Int() < vb.Int()
+	case 3:
+		return va.Uint() < vb.Uint()
+	case 4:
+		fa, fb := va.Float(), vb.Float()
+		// NaN sorts before all other floats so the order stays total
+		if math.IsNaN(fa) {
+			return !math.IsNaN(fb)
+		}
+		if math.IsNaN(fb) {
+			return false
+		}
+		return fa < fb
+	case 5:
+		return va.String() < vb.String()
+	case 6:
+		return fmt.Sprint(va.Interface()) < fmt.Sprint(vb.Interface())
+	}
+	return false
+}
 
 func newRecursionDetector() *recursionDetector {
 	return &recursionDetector{visited: make(map[uintptr]struct{})}

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -287,8 +287,10 @@ func makeDictTag(val reflect.Value, tagName string) (starlark.Value, error) {
 		// panic if not a map
 		panic(fmt.Errorf("can't make map of %T", val.Interface()))
 	} else if valid {
-		// iterate over the map and convert each key and value
-		for _, k := range val.MapKeys() {
+		// iterate over the map and convert each key and value, in
+		// deterministic key order: Starlark dicts preserve insertion order,
+		// so the random order of MapKeys would be script-visible
+		for _, k := range sortedMapKeys(val) {
 			vk, err := adjustedToValue(k, tagName)
 			if err != nil {
 				return nil, err
@@ -462,6 +464,21 @@ func MakeSetFromSlice(s []interface{}) (*starlark.Set, error) {
 		}
 	}
 	return &set, nil
+}
+
+// FromSetToSlice converts a starlark.Set into a []interface{}, preserving
+// the set's iteration (insertion) order. Use it instead of FromSet when the
+// order of members matters: FromSet returns a Go map, which has no defined
+// iteration order.
+func FromSetToSlice(s *starlark.Set) []interface{} {
+	ret := make([]interface{}, 0, s.Len())
+	var v starlark.Value
+	i := s.Iterate()
+	defer i.Done()
+	for i.Next(&v) {
+		ret = append(ret, FromValue(v))
+	}
+	return ret
 }
 
 // FromSet converts a starlark.Set to a map[interface{}]bool.

--- a/convert/map.go
+++ b/convert/map.go
@@ -163,7 +163,7 @@ func (g *GoMap) delete(key reflect.Value) (v starlark.Value, found bool, err err
 func (g *GoMap) Items() []starlark.Tuple {
 	tuples := make([]starlark.Tuple, 0, g.v.Len())
 	var err error
-	for _, k := range g.v.MapKeys() {
+	for _, k := range sortedMapKeys(g.v) {
 		tuple := make(starlark.Tuple, 2)
 		tuple[0], err = toValue(k, g.tag)
 		if err != nil {
@@ -180,7 +180,7 @@ func (g *GoMap) Items() []starlark.Tuple {
 
 func (g *GoMap) Keys() []starlark.Value {
 	keys := make([]starlark.Value, 0, g.v.Len())
-	for _, k := range g.v.MapKeys() {
+	for _, k := range sortedMapKeys(g.v) {
 		key, err := toValue(k, g.tag)
 		if err != nil {
 			panic(err)
@@ -198,7 +198,7 @@ func (g *GoMap) Iterate() starlark.Iterator {
 	g.numIt++
 	return &mapIterator{
 		g:    g,
-		keys: g.v.MapKeys(),
+		keys: sortedMapKeys(g.v),
 	}
 }
 
@@ -336,7 +336,7 @@ func dict_popitem(fnname string, g *GoMap, args starlark.Tuple, _ []starlark.Tup
 	if len(args) > 0 {
 		return nil, fmt.Errorf("%s: wanted 0 args, got %d", fnname, len(args))
 	}
-	keys := g.v.MapKeys()
+	keys := sortedMapKeys(g.v)
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("popitem: empty dict")
 	}

--- a/convert/order_test.go
+++ b/convert/order_test.go
@@ -1,0 +1,141 @@
+package convert_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// Regression tests for deterministic key order: Go's map iteration order is
+// randomized, and it used to leak into Starlark through every place a
+// wrapped Go map was materialized (keys/items/values/iteration/popitem and
+// MakeDict), so the same script over the same data produced different
+// orders on every run. Keys must come out in a deterministic order: sorted
+// by type rank (bool < int < uint < float < string < other), then by value
+// within the same rank.
+
+// TestGoMapDeterministicKeyOrder verifies that scripts observe wrapped Go
+// map keys in sorted order through keys/items/values and iteration.
+func TestGoMapDeterministicKeyOrder(t *testing.T) {
+	m := map[string]int{}
+	for i := 0; i < 50; i++ {
+		m[fmt.Sprintf("key%02d", i)] = i
+	}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+ks = m.keys()
+assert.Eq(sorted(ks), ks)
+assert.Eq(len(ks), 50)
+assert.Eq([k for k in m], ks)
+assert.Eq([i[0] for i in m.items()], ks)
+assert.Eq([m[k] for k in ks], [i[1] for i in m.items()])
+assert.Eq(m.values(), [m[k] for k in ks])
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGoMapMixedKeyTypeOrder verifies the documented type-rank order for
+// interface-keyed maps holding keys of mixed Go types.
+func TestGoMapMixedKeyTypeOrder(t *testing.T) {
+	m := map[interface{}]interface{}{
+		"b":          1,
+		"a":          2,
+		int64(7):     3,
+		int32(5):     4,
+		uint16(9):    5,
+		false:        6,
+		true:         7,
+		float64(2.5): 8,
+	}
+	g := convert.NewGoMap(m)
+	var got []string
+	for _, k := range g.Keys() {
+		got = append(got, k.String())
+	}
+	// bool < int < uint < float < string; within a rank, by value
+	// (interface-typed keys come out wrapped, hence the plain formatting)
+	want := []string{"false", "true", "5", "7", "9", "2.5", "a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected key order %v, got %v", want, got)
+		}
+	}
+}
+
+// TestMakeDictDeterministicOrder verifies MakeDict materializes Go map
+// entries into the Starlark dict in sorted key order (Starlark dicts
+// preserve insertion order, so this is script-visible).
+func TestMakeDictDeterministicOrder(t *testing.T) {
+	m := map[string]int{}
+	var want []starlark.Value
+	for i := 0; i < 26; i++ {
+		k := fmt.Sprintf("k%c", 'a'+i)
+		m[k] = i
+		want = append(want, starlark.String(k))
+	}
+	v, err := convert.MakeDict(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := v.(*starlark.Dict)
+	keys := d.Keys()
+	if len(keys) != len(want) {
+		t.Fatalf("expected %d keys, got %d", len(want), len(keys))
+	}
+	for i := range want {
+		if keys[i] != want[i] {
+			t.Fatalf("expected key order %v, got %v", want, keys)
+		}
+	}
+}
+
+// TestGoMapPopitemDeterministic verifies popitem pops entries in sorted key
+// order instead of a random one.
+func TestGoMapPopitemDeterministic(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+assert.Eq(m.popitem(), ("a", 1))
+assert.Eq(m.popitem(), ("b", 2))
+assert.Eq(m.popitem(), ("c", 3))
+assert.Eq(len(m), 0)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestFromSetToSlice verifies the new ordered set materialization keeps the
+// set's insertion order, unlike FromSet which returns an unordered Go map.
+func TestFromSetToSlice(t *testing.T) {
+	s := starlark.NewSet(3)
+	for _, v := range []string{"c", "a", "b"} {
+		if err := s.Insert(starlark.String(v)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := convert.FromSetToSlice(s)
+	want := []interface{}{"c", "a", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Go's randomized map iteration order leaked into Starlark at every point a wrapped Go map is materialized — `keys()`/`items()`/`values()`, iteration, `popitem()`, and `MakeDict` (Starlark dicts preserve insertion order, so the random order was script-visible). The same script over the same data produced a different order on every run, breaking reproducibility.

## Fix

- New `sortedMapKeys` helper returns a deterministic snapshot of map keys: sorted by type rank (`nil < bool < int < uint < float < string < other`), then by value within the same rank; `NaN` sorts before other floats so the ordering stays total; `other` ranks compare by printed form.
- Applied at every observable materialization point: `GoMap.Items/Keys/Iterate`, `popitem`, and `makeDictTag`. (`convertMap` output is a Go map with no observable order and is intentionally left untouched.)
- New `FromSetToSlice` materializes a Starlark set preserving its insertion order, for callers that need ordered output; `FromSet` keeps returning an unordered Go map.

## Tests

New `convert/order_test.go`: 50-key script-level assertions over `keys/items/values`/iteration, mixed-type key rank order, `MakeDict` insertion order, deterministic `popitem`, and `FromSetToSlice` order — run with `-count=5` locally to confirm stability. Full suite passes with `-race` on Go 1.25 and on Go 1.18/1.19 (Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)