### PR TITLE
fix: guard String() against self-referential values

### DIFF
--- a/convert/common.go
+++ b/convert/common.go
@@ -89,6 +89,74 @@ func keyLess(a, b reflect.Value) bool {
 	return false
 }
 
+// maxSafeStringDepth bounds the pre-scan in safeGoString; values nested
+// deeper than this are treated as unsafe to print, since fmt.Sprint would
+// recurse at least as deep on them.
+const maxSafeStringDepth = 100
+
+// safeGoString formats a wrapped Go value like fmt.Sprint, but first scans
+// it for reference cycles: fmt.Sprint recurses forever on a map or slice
+// that reaches itself, killing the process with an unrecoverable fatal
+// stack overflow. Values containing a cycle (or nested deeper than
+// maxSafeStringDepth) format as "<cyclic TYPE>" instead; all other values
+// format exactly as fmt.Sprint does.
+func safeGoString(v reflect.Value) string {
+	if !v.IsValid() {
+		return "<invalid>"
+	}
+	if hasRefCycle(v, make(map[uintptr]bool), 0) {
+		return fmt.Sprintf("<cyclic %s>", v.Type())
+	}
+	return fmt.Sprint(v.Interface())
+}
+
+// hasRefCycle reports whether v reaches itself through maps, slices,
+// pointers, or interfaces, or nests deeper than maxSafeStringDepth. The
+// visited set tracks pointers on the current DFS path only, so shared
+// (but acyclic) substructures are not misreported.
+func hasRefCycle(v reflect.Value, visited map[uintptr]bool, depth int) bool {
+	if depth > maxSafeStringDepth {
+		return true
+	}
+	switch v.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Ptr:
+		if v.IsNil() {
+			return false
+		}
+		p := v.Pointer()
+		if visited[p] {
+			return true
+		}
+		visited[p] = true
+		defer delete(visited, p)
+	}
+	switch v.Kind() {
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			if hasRefCycle(k, visited, depth+1) || hasRefCycle(v.MapIndex(k), visited, depth+1) {
+				return true
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if hasRefCycle(v.Index(i), visited, depth+1) {
+				return true
+			}
+		}
+	case reflect.Ptr, reflect.Interface:
+		if !v.IsNil() {
+			return hasRefCycle(v.Elem(), visited, depth+1)
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if hasRefCycle(v.Field(i), visited, depth+1) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func newRecursionDetector() *recursionDetector {
 	return &recursionDetector{visited: make(map[uintptr]struct{})}
 }

--- a/convert/interface.go
+++ b/convert/interface.go
@@ -92,9 +92,10 @@ func (g *GoInterface) AttrNames() []string {
 }
 
 // String returns the string representation of the value.
-// Starlark string values are quoted as if by Python's repr.
+// Cyclic or overly deep values are elided as "<cyclic TYPE>" instead of
+// overflowing the stack; see safeGoString.
 func (g *GoInterface) String() string {
-	return fmt.Sprint(g.v.Interface())
+	return safeGoString(g.v)
 }
 
 // Type returns a short string describing the value's type.

--- a/convert/map.go
+++ b/convert/map.go
@@ -82,9 +82,10 @@ func (g *GoMap) Get(in starlark.Value) (out starlark.Value, found bool, err erro
 }
 
 // String returns the string representation of the value.
-// Starlark string values are quoted as if by Python's repr.
+// Cyclic or overly deep values are elided as "<cyclic TYPE>" instead of
+// overflowing the stack; see safeGoString.
 func (g *GoMap) String() string {
-	return fmt.Sprint(g.v.Interface())
+	return safeGoString(g.v)
 }
 
 // Type returns a short string describing the value's type.

--- a/convert/safestring_test.go
+++ b/convert/safestring_test.go
@@ -1,0 +1,121 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+)
+
+// Regression tests for self-referential Go values: String() used fmt.Sprint
+// with no cycle detection, so a Go map or slice that reaches itself made
+// String() recurse forever and killed the process with an unrecoverable
+// fatal stack overflow. Cyclic values must format as "<cyclic TYPE>"; plain
+// values must keep their exact previous formatting.
+
+// TestGoMapSelfRefString verifies a self-referential map formats safely.
+func TestGoMapSelfRefString(t *testing.T) {
+	m := map[string]interface{}{}
+	m["self"] = m
+	got := convert.NewGoMap(m).String()
+	if !strings.Contains(got, "cyclic") {
+		t.Fatalf("expected cyclic marker, got %q", got)
+	}
+}
+
+// TestGoSliceSelfRefString verifies a self-referential slice formats safely.
+func TestGoSliceSelfRefString(t *testing.T) {
+	s := make([]interface{}, 1)
+	s[0] = s
+	v, err := convert.ToValue(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := v.String()
+	if !strings.Contains(got, "cyclic") {
+		t.Fatalf("expected cyclic marker, got %q", got)
+	}
+}
+
+// TestGoStructSelfRefString verifies a struct whose field holds a
+// self-referential map formats safely.
+func TestGoStructSelfRefString(t *testing.T) {
+	type node struct {
+		M map[string]interface{}
+	}
+	n := node{M: map[string]interface{}{}}
+	n.M["self"] = n.M
+	v, err := convert.ToValue(n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := v.String()
+	if !strings.Contains(got, "cyclic") {
+		t.Fatalf("expected cyclic marker, got %q", got)
+	}
+}
+
+// TestScriptStrSelfRef verifies str() in a script cannot crash the host on
+// self-referential values, including the GoInterface wrapping that map
+// element access produces.
+func TestScriptStrSelfRef(t *testing.T) {
+	m := map[string]interface{}{}
+	m["self"] = m
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+s1 = str(m)
+s2 = str(m["self"])
+assert.Eq("cyclic" in s1, True)
+assert.Eq("cyclic" in s2, True)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestStringFormattingUnchanged pins the exact previous formatting for
+// ordinary (acyclic) values.
+func TestStringFormattingUnchanged(t *testing.T) {
+	if got := convert.NewGoMap(map[string]int{"a": 1}).String(); got != "map[a:1]" {
+		t.Fatalf("map formatting changed: %q", got)
+	}
+	sv, err := convert.ToValue([]int{1, 2, 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := sv.String(); got != "[1 2 3]" {
+		t.Fatalf("slice formatting changed: %q", got)
+	}
+	type pair struct {
+		A int
+		B string
+	}
+	pv, err := convert.ToValue(pair{A: 1, B: "bob"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := pv.String(); got != "{1 bob}" {
+		t.Fatalf("struct formatting changed: %q", got)
+	}
+}
+
+// TestStringDeepNesting verifies that absurdly deep (but finite) values are
+// elided rather than allowed to recurse toward a stack overflow.
+func TestStringDeepNesting(t *testing.T) {
+	var nest interface{} = []interface{}{}
+	for i := 0; i < 500; i++ {
+		nest = []interface{}{nest}
+	}
+	v, err := convert.ToValue(nest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := v.String()
+	if !strings.Contains(got, "cyclic") {
+		t.Fatalf("expected deep value to be elided, got %d chars", len(got))
+	}
+}

--- a/convert/slice.go
+++ b/convert/slice.go
@@ -34,9 +34,10 @@ func NewGoSlice(slice interface{}) *GoSlice {
 }
 
 // String returns the string representation of the value.
-// Starlark string values are quoted as if by Python's repr.
+// Cyclic or overly deep values are elided as "<cyclic TYPE>" instead of
+// overflowing the stack; see safeGoString.
 func (g *GoSlice) String() string {
-	return fmt.Sprint(g.v.Interface())
+	return safeGoString(g.v)
 }
 
 // Type returns a short string describing the value's type.

--- a/convert/struct.go
+++ b/convert/struct.go
@@ -236,9 +236,10 @@ func (g *GoStruct) SetField(name string, val starlark.Value) error {
 }
 
 // String returns the string representation of the value.
-// Starlark string values are quoted as if by Python's repr.
+// Cyclic or overly deep values are elided as "<cyclic TYPE>" instead of
+// overflowing the stack; see safeGoString.
 func (g *GoStruct) String() string {
-	return fmt.Sprint(g.v.Interface())
+	return safeGoString(g.v)
 }
 
 // Type returns a short string describing the value's type.


### PR DESCRIPTION
## Problem

`GoMap/GoSlice/GoStruct/GoInterface.String()` formatted the wrapped value with `fmt.Sprint`, which recurses forever on a Go map or slice that reaches itself. The result is an unrecoverable **fatal stack overflow** that kills the host process — `str(m)` in a script was enough to trigger it. (Pointer rings were already safe; only self-referential maps/slices crashed.)

## Fix

- New `safeGoString` pre-scans the value for reference cycles using a DFS path-marking pointer set plus a depth bound (100, matching the recursion `fmt.Sprint` would need). Cyclic or overly deep values format as `<cyclic TYPE>`; everything else keeps the exact `fmt.Sprint` formatting (pinned by test).
- Wired into all four `String()` implementations.
- Dropped the stale "quoted as if by Python's repr" doc comment that never matched actual behavior.

This is prevention at the formatting boundary — the cycle can still exist in the data; it just can no longer kill the process when printed.

## Tests

New `convert/safestring_test.go`: self-referential map/slice/struct-field, script-level `str()` on cyclic values (incl. the GoInterface path from element access), exact formatting pins for ordinary values, and a 500-deep nesting guard. Full suite passes with `-race` on Go 1.25 and on Go 1.18/1.19 (Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)