### PR TITLE
fix: eliminate four script-reachable panics

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -102,11 +102,17 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	case reflect.Func:
 		return makeStarFn("fn", val, tagName), nil
 	case reflect.Map:
+		if err := checkCollectionElemTypes(val.Type(), nil); err != nil {
+			return nil, err
+		}
 		return &GoMap{v: val, tag: tagName}, nil
 	case reflect.String:
 		return starlark.String(val.String()), nil
 	case reflect.Slice, reflect.Array:
-		return &GoSlice{v: val, tag: tagName}, nil
+		if err := checkCollectionElemTypes(val.Type(), nil); err != nil {
+			return nil, err
+		}
+		return &GoSlice{v: arrayToSlice(val), tag: tagName}, nil
 	case reflect.Struct:
 		// handle special case from standard starlark lib
 		switch val.Type() {
@@ -126,6 +132,37 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	}
 
 	return nil, fmt.Errorf("type %T is not a supported starlark type", val.Interface())
+}
+
+// checkCollectionElemTypes verifies that the key and element types of a map,
+// or the element type of a slice or array, are convertible by toValue,
+// recursing through nested collection and pointer types. Without this
+// pre-check, a collection like map[string]chan int converted fine and blew
+// up with a panic only later, when items() or iteration touched a value of
+// the unsupported type. Struct types are not descended into: their fields
+// are reached through GoStruct.Attr, which reports a regular error. The
+// visited set guards against recursive Go types (e.g. type M map[string]M);
+// pass nil to start.
+func checkCollectionElemTypes(t reflect.Type, visited map[reflect.Type]bool) error {
+	if visited[t] {
+		return nil
+	}
+	if visited == nil {
+		visited = make(map[reflect.Type]bool)
+	}
+	visited[t] = true
+	switch t.Kind() {
+	case reflect.Chan, reflect.Complex64, reflect.Complex128, reflect.UnsafePointer, reflect.Uintptr:
+		return fmt.Errorf("type %s is not a supported starlark type", t)
+	case reflect.Map:
+		if err := checkCollectionElemTypes(t.Key(), visited); err != nil {
+			return err
+		}
+		return checkCollectionElemTypes(t.Elem(), visited)
+	case reflect.Slice, reflect.Array, reflect.Ptr:
+		return checkCollectionElemTypes(t.Elem(), visited)
+	}
+	return nil
 }
 
 // FromValue converts a starlark value to a go value.

--- a/convert/map.go
+++ b/convert/map.go
@@ -47,6 +47,11 @@ func (g *GoMap) SetKey(k, v starlark.Value) (err error) {
 	if g.numIt > 0 {
 		return fmt.Errorf("cannot insert into map during iteration")
 	}
+	if g.v.IsNil() {
+		// writing to a nil Go map is a runtime panic in Go; surface it as a
+		// regular error (the host must initialize the map before sharing it)
+		return fmt.Errorf("cannot insert into nil map")
+	}
 
 	key, err := tryKeyConv(k, g.v.Type().Key())
 	if err != nil {

--- a/convert/map_test.go
+++ b/convert/map_test.go
@@ -501,27 +501,19 @@ f()
 }
 
 func TestMapUnsupportedType(t *testing.T) {
-	globals := map[string]interface{}{
-		"assert": &assert{t: t},
-		"m1":     map[chan int]int{make(chan int): 2},
-		"m2":     map[int]chan string{2: make(chan string)},
+	// maps with key or element types that toValue cannot convert are
+	// rejected at conversion time, before any script runs (previously they
+	// wrapped fine and every later access errored or panicked)
+	for _, tc := range []struct {
+		m   interface{}
+		err string
+	}{
+		{map[chan int]int{make(chan int): 2}, "type chan int is not a supported starlark type"},
+		{map[int]chan string{2: make(chan string)}, "type chan string is not a supported starlark type"},
+	} {
+		_, err := starlight.Eval([]byte(`x = 1`), map[string]interface{}{"m": tc.m}, nil)
+		expectErr(t, err, tc.err)
 	}
-
-	code := []byte(`m1[1] = 1`)
-	_, err := starlight.Eval(code, globals, nil)
-	expectErr(t, err, "setkey key: value of type int64 cannot be converted to type chan int")
-
-	code = []byte(`val = m1[2]`)
-	_, err = starlight.Eval(code, globals, nil)
-	expectErr(t, err, "get: value of type int64 cannot be converted to type chan int")
-
-	code = []byte(`m2[1] = "test"`)
-	_, err = starlight.Eval(code, globals, nil)
-	expectErr(t, err, "setkey value: value of type string cannot be converted to type chan string")
-
-	code = []byte(`val = m2[2]`)
-	_, err = starlight.Eval(code, globals, nil)
-	expectErr(t, err, "type chan string is not a supported starlark type")
 }
 
 // intMap converts from a starlark-created map to a map[int]int

--- a/convert/panics_test.go
+++ b/convert/panics_test.go
@@ -1,0 +1,136 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+)
+
+// Regression tests for the four script-reachable panics:
+//  1. strided slicing (l[::2]) passed the element type to MakeSlice and
+//     panicked on every use — strided slices never worked;
+//  2. first write to a wrapped nil Go map panicked with "assignment to
+//     entry in nil map";
+//  3. Go arrays were wrapped as GoSlice but append/assignment panicked
+//     (reflect.Append on array / unaddressable value);
+//  4. collections with element types toValue cannot convert (e.g. chan)
+//     wrapped fine but panicked later in items()/iteration.
+
+// TestStridedSlice verifies strided slicing works instead of panicking.
+func TestStridedSlice(t *testing.T) {
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"l":      []int{1, 2, 3, 4, 5, 6},
+	}
+	code := []byte(`
+l2 = l[::2]
+assert.Eq(len(l2), 3)
+assert.Eq(l2[0], 1)
+assert.Eq(l2[1], 3)
+assert.Eq(l2[2], 5)
+l3 = l[::-1]
+assert.Eq(len(l3), 6)
+assert.Eq(l3[0], 6)
+assert.Eq(l3[5], 1)
+l4 = l[1:5:2]
+assert.Eq(len(l4), 2)
+assert.Eq(l4[0], 2)
+assert.Eq(l4[1], 4)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNilMapWrite verifies the first write to a wrapped nil Go map is a
+// regular error instead of a panic, and that reads stay graceful.
+func TestNilMapWrite(t *testing.T) {
+	var m map[string]int
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+assert.Eq(len(m), 0)
+assert.Eq(m.get("a", 42), 42)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	_, err := starlight.Eval([]byte(`m["a"] = 1`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "nil map") {
+		t.Fatalf("expected nil map error, got %v", err)
+	}
+	_, err = starlight.Eval([]byte(`m.setdefault("a", 1)`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "nil map") {
+		t.Fatalf("expected nil map error, got %v", err)
+	}
+}
+
+// TestArrayWrap verifies Go arrays are usable from scripts: they are copied
+// into a slice at conversion time, so append/assignment work on the copy
+// instead of panicking.
+func TestArrayWrap(t *testing.T) {
+	arr := [3]int{1, 2, 3}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"a":      arr,
+	}
+	code := []byte(`
+assert.Eq(len(a), 3)
+a.append(4)
+assert.Eq(len(a), 4)
+assert.Eq(a[3], 4)
+a[0] = 10
+assert.Eq(a[0], 10)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	if arr != [3]int{1, 2, 3} {
+		t.Fatalf("expected host array to be unchanged (copy semantics), got %v", arr)
+	}
+	// the explicit constructor follows the same copy rule
+	g := convert.NewGoSlice([2]string{"a", "b"})
+	if g.Len() != 2 {
+		t.Fatalf("expected wrapped array len 2, got %d", g.Len())
+	}
+}
+
+// TestUnsupportedElemType verifies collections whose static element (or
+// key) type cannot be converted are rejected at conversion time with an
+// error, instead of converting fine and panicking later in items() or
+// iteration.
+func TestUnsupportedElemType(t *testing.T) {
+	for _, v := range []interface{}{
+		map[string]chan int{"c": make(chan int)},
+		[]chan int{make(chan int)},
+		map[chan int]string{},
+		map[string][]chan int{},
+		[][]chan int{},
+		[]complex128{1i},
+	} {
+		if _, err := convert.ToValue(v); err == nil {
+			t.Errorf("expected conversion error for %T, got nil", v)
+		}
+	}
+
+	// recursive types must not hang the type pre-check
+	type recMap map[string]interface{}
+	rm := recMap{}
+	rm["self"] = rm
+	if _, err := convert.ToValue(rm); err != nil {
+		t.Errorf("expected recursive-but-supported type to convert, got %v", err)
+	}
+
+	// script-level: the error must surface as a regular error, not a panic
+	globals := map[string]interface{}{
+		"m": map[string]chan int{"c": make(chan int)},
+	}
+	_, err := starlight.Eval([]byte(`x = len(m)`), globals, nil)
+	if err == nil {
+		t.Fatal("expected conversion error for chan-valued map global")
+	}
+}

--- a/convert/slice.go
+++ b/convert/slice.go
@@ -14,7 +14,10 @@ import (
 // https://github.com/google/starlark-go/blob/master/starlark/value.go#L666
 // Which is Copyright 2017 The Bazel Authors and uses a BSD 3-clause license.
 
-// GoSlice is a wrapper around a Go slice to adapt it for use with starlark.
+// GoSlice is a wrapper around a Go slice or array to adapt it for use with
+// starlark. Arrays are copied into a slice at wrap time: they arrive by
+// value (unaddressable) through interface{}, so in-place mutation could
+// never reach the host's array anyway — mutations affect the copy only.
 type GoSlice struct {
 	_      DoNotCompare
 	v      reflect.Value
@@ -23,14 +26,28 @@ type GoSlice struct {
 	frozen bool
 }
 
-// NewGoSlice wraps the given slice in a new GoSlice.
-// This function will panic if m is nil or not a slice nor array.
+// NewGoSlice wraps the given slice or array in a new GoSlice; arrays are
+// copied into a slice (see the GoSlice doc).
+// This function will panic if the argument is not a slice nor an array.
 func NewGoSlice(slice interface{}) *GoSlice {
 	v := reflect.ValueOf(slice)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		panic(fmt.Errorf("NewGoSlice expects a slice or array, but got %T", slice))
 	}
-	return &GoSlice{v: v}
+	return &GoSlice{v: arrayToSlice(v)}
+}
+
+// arrayToSlice returns v unchanged for slices, and a freshly allocated
+// slice copy for arrays: reflect.Append and Index().Set panic on array
+// values (they are unaddressable copies), so wrapping the copy is the only
+// way to make arrays usable from scripts.
+func arrayToSlice(v reflect.Value) reflect.Value {
+	if v.Kind() != reflect.Array {
+		return v
+	}
+	s := reflect.MakeSlice(reflect.SliceOf(v.Type().Elem()), v.Len(), v.Len())
+	reflect.Copy(s, v)
+	return s
 }
 
 // String returns the string representation of the value.
@@ -108,7 +125,7 @@ func (g *GoSlice) Slice(start, end, step int) starlark.Value {
 		reflect.Copy(cp, g.v.Slice(start, end))
 		return &GoSlice{v: cp}
 	}
-	cp := reflect.MakeSlice(g.v.Type().Elem(), 0, 0)
+	cp := reflect.MakeSlice(g.v.Type(), 0, 0)
 	sign := signOf(step)
 	for i := start; signOf(end-i) == sign; i += step {
 		cp = reflect.Append(cp, g.v.Index(i))

--- a/convert/slice_test.go
+++ b/convert/slice_test.go
@@ -405,23 +405,28 @@ assert.Eq(x4, intSlice([3,4]))
 }
 
 func TestSliceUnsupportedType(t *testing.T) {
-	globals := map[string]interface{}{
-		"assert": &assert{t: t},
-		"s1":     []chan int{},
-		"s2":     []chan int{make(chan int), make(chan int, 1), make(chan int, 2)},
+	// slices with element types that toValue cannot convert are rejected at
+	// conversion time, before any script runs (previously they wrapped fine
+	// and every later access errored or panicked)
+	for _, sl := range []interface{}{
+		[]chan int{},
+		[]chan int{make(chan int), make(chan int, 1), make(chan int, 2)},
+	} {
+		_, err := starlight.Eval([]byte(`x = 1`), map[string]interface{}{"s": sl}, nil)
+		expectErr(t, err, "type chan int is not a supported starlark type")
 	}
 
-	code := []byte(`s1.append(1)`)
+	// indexing errors on supported slices stay graceful
+	globals := map[string]interface{}{
+		"s2": []int{1, 2, 3},
+	}
+	code := []byte(`val = s2[]`)
 	_, err := starlight.Eval(code, globals, nil)
-	expectErr(t, err, "append: value of type int64 cannot be converted to type chan int")
-
-	code = []byte(`val = s2[]`)
-	_, err = starlight.Eval(code, globals, nil)
 	expectErr(t, err, "eval.sky:1:11: got ']', want primary expression")
 
 	code = []byte(`val = s2["foo"]`)
 	_, err = starlight.Eval(code, globals, nil)
-	expectErr(t, err, "starlight_slice<[]chan int> index: got string, want int")
+	expectErr(t, err, "starlight_slice<[]int> index: got string, want int")
 }
 
 // func TestSlicePlus(t *testing.T) {


### PR DESCRIPTION
## Problem

Four ways a plain script could panic and kill the host process:

1. **Strided slicing never worked**: `l[::2]` passed the *element* type to `reflect.MakeSlice` and panicked on every use.
2. **First write to a wrapped nil Go map** panicked with `assignment to entry in nil map`.
3. **Go arrays** were wrapped as `GoSlice`, but every mutation panicked (`reflect.Append` on an array / unaddressable value).
4. **Collections with unconvertible element types** (e.g. `map[string]chan int`) wrapped fine, then panicked only later when `items()` or iteration touched a value.

## Fix

1. Strided `Slice` builds the copy with the slice type; tests cover positive/negative/offset strides.
2. `GoMap.SetKey` returns a regular error on nil maps (reads were already graceful).
3. Arrays are copied into a slice at wrap time (`toValue` and `NewGoSlice`). They arrive by value through `interface{}` anyway, so in-place mutation could never reach the host's array — documented on `GoSlice`.
4. New `checkCollectionElemTypes` rejects unsupported key/element types at conversion time with a regular error, recursing through nested collection/pointer types (visited set guards recursive Go types like `type M map[string]M`). Struct types stay opaque: their fields go through `GoStruct.Attr`, which already errors gracefully.

The blanket `recover` in `toValue` is intentionally untouched here, so each fix is verifiable on its own.

`TestMapUnsupportedType`/`TestSliceUnsupportedType` pinned the old wrap-now-fail-later behavior and are updated for conversion-time rejection.

## Tests

New `convert/panics_test.go` covers all four classes at script level and API level. Full suite passes with `-race` on Go 1.25 and on Go 1.18/1.19 (Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)