### PR TITLE
perf: cut overhead of determinism and safety pre-checks

### DIFF
--- a/convert/bench_test.go
+++ b/convert/bench_test.go
@@ -1,0 +1,96 @@
+package convert_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// Benchmarks for the conversion hot paths touched by the panic/determinism
+// fixes: key materialization (sorted snapshots), String() (cycle pre-scan),
+// map get/set (key conversion pre-checks), and collection wrapping (static
+// element type checks).
+
+func benchMap(n int) map[string]int {
+	m := make(map[string]int, n)
+	for i := 0; i < n; i++ {
+		m[fmt.Sprintf("key%04d", i)] = i
+	}
+	return m
+}
+
+func BenchmarkGoMapKeys50(b *testing.B) {
+	g := convert.NewGoMap(benchMap(50))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.Keys()
+	}
+}
+
+func BenchmarkGoMapItems50(b *testing.B) {
+	g := convert.NewGoMap(benchMap(50))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.Items()
+	}
+}
+
+func BenchmarkGoMapString50(b *testing.B) {
+	g := convert.NewGoMap(benchMap(50))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.String()
+	}
+}
+
+func BenchmarkGoSliceString1k(b *testing.B) {
+	s := make([]int, 1000)
+	for i := range s {
+		s[i] = i
+	}
+	g := convert.NewGoSlice(s)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = g.String()
+	}
+}
+
+func BenchmarkGoMapSetGet(b *testing.B) {
+	g := convert.NewGoMap(map[string]int{})
+	k := starlark.String("key")
+	v := starlark.MakeInt(42)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := g.SetKey(k, v); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := g.Get(k); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkToValueMap50(b *testing.B) {
+	m := benchMap(50)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := convert.ToValue(m); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFromDict50(b *testing.B) {
+	d := starlark.NewDict(50)
+	for i := 0; i < 50; i++ {
+		if err := d.SetKey(starlark.String(fmt.Sprintf("key%04d", i)), starlark.MakeInt(i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = convert.FromDict(d)
+	}
+}

--- a/convert/common.go
+++ b/convert/common.go
@@ -26,67 +26,122 @@ var (
 // map iteration order, which would otherwise leak into Starlark everywhere
 // a wrapped Go map is materialized (keys/items/values/iteration/popitem and
 // MakeDict) and make script output non-reproducible across runs.
+//
+// The sort key for every map key is extracted exactly once up front
+// (decorate-sort-undecorate), so the comparison function stays free of
+// reflection.
 func sortedMapKeys(m reflect.Value) []reflect.Value {
 	keys := m.MapKeys()
-	sort.SliceStable(keys, func(i, j int) bool { return keyLess(keys[i], keys[j]) })
+	decorated := make(sortableKeys, len(keys))
+	for i, k := range keys {
+		decorated[i] = decorateKey(k)
+	}
+	sort.Sort(decorated)
+	for i := range decorated {
+		keys[i] = decorated[i].orig
+	}
 	return keys
 }
 
-// keyRank classifies a map key for sorting: it unwraps interface keys to
-// their dynamic value and returns the type rank along with the unwrapped
-// value used for same-rank comparison.
-func keyRank(v reflect.Value) (int, reflect.Value) {
-	if v.Kind() == reflect.Interface {
-		if v.IsNil() {
-			return 0, v
-		}
-		v = v.Elem()
-	}
-	switch v.Kind() {
-	case reflect.Bool:
-		return 1, v
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return 2, v
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return 3, v
-	case reflect.Float32, reflect.Float64:
-		return 4, v
-	case reflect.String:
-		return 5, v
-	}
-	return 6, v
+// sortableKeys implements sort.Interface with concrete methods (the
+// reflect-based swapping of sort.Slice* is measurably slower here).
+type sortableKeys []sortableKey
+
+func (s sortableKeys) Len() int           { return len(s) }
+func (s sortableKeys) Less(i, j int) bool { return sortableKeyLess(s[i], s[j]) }
+func (s sortableKeys) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// sortableKey carries a map key's type rank and its primitive sort key,
+// extracted once so sorting does not call into reflect per comparison.
+type sortableKey struct {
+	rank int
+	i    int64
+	u    uint64
+	f    float64
+	s    string
+	orig reflect.Value
 }
 
-// keyLess is the strict weak ordering used by sortedMapKeys.
-func keyLess(a, b reflect.Value) bool {
-	ra, va := keyRank(a)
-	rb, vb := keyRank(b)
-	if ra != rb {
-		return ra < rb
+// decorateKey classifies a map key for sorting: it unwraps interface keys
+// to their dynamic value and extracts the primitive used for same-rank
+// comparison.
+func decorateKey(v reflect.Value) sortableKey {
+	k := sortableKey{orig: v}
+	u := v
+	if u.Kind() == reflect.Interface {
+		if u.IsNil() {
+			return k // rank 0: nil sorts first
+		}
+		u = u.Elem()
 	}
-	switch ra {
-	case 1:
-		return !va.Bool() && vb.Bool()
-	case 2:
-		return va.Int() < vb.Int()
-	case 3:
-		return va.Uint() < vb.Uint()
+	switch u.Kind() {
+	case reflect.Bool:
+		k.rank = 1
+		if u.Bool() {
+			k.i = 1
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		k.rank = 2
+		k.i = u.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		k.rank = 3
+		k.u = u.Uint()
+	case reflect.Float32, reflect.Float64:
+		k.rank = 4
+		k.f = u.Float()
+	case reflect.String:
+		k.rank = 5
+		k.s = u.String()
+	default:
+		k.rank = 6
+		k.s = fmt.Sprint(u.Interface())
+	}
+	return k
+}
+
+// sortableKeyLess is the strict weak ordering used by sortedMapKeys. Keys
+// of different concrete types can tie on rank and value (e.g. int8(5) and
+// int64(5) in an interface-keyed map); the tie is broken by the concrete
+// type name, lazily, so the order stays fully deterministic without paying
+// for type-name extraction on every key.
+func sortableKeyLess(a, b sortableKey) bool {
+	if a.rank != b.rank {
+		return a.rank < b.rank
+	}
+	switch a.rank {
+	case 1, 2:
+		if a.i != b.i {
+			return a.i < b.i
+		}
 	case 4:
-		fa, fb := va.Float(), vb.Float()
 		// NaN sorts before all other floats so the order stays total
-		if math.IsNaN(fa) {
-			return !math.IsNaN(fb)
+		an, bn := math.IsNaN(a.f), math.IsNaN(b.f)
+		if an || bn {
+			return an && !bn
 		}
-		if math.IsNaN(fb) {
-			return false
+		if a.f != b.f {
+			return a.f < b.f
 		}
-		return fa < fb
-	case 5:
-		return va.String() < vb.String()
-	case 6:
-		return fmt.Sprint(va.Interface()) < fmt.Sprint(vb.Interface())
+	case 3:
+		if a.u != b.u {
+			return a.u < b.u
+		}
+	case 5, 6:
+		if a.s != b.s {
+			return a.s < b.s
+		}
+	default:
+		return false
 	}
-	return false
+	return keyTypeName(a.orig) < keyTypeName(b.orig)
+}
+
+// keyTypeName names the concrete type of a map key for tie-breaking.
+func keyTypeName(v reflect.Value) string {
+	if v.Kind() == reflect.Interface && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v.Type().String()
 }
 
 // maxSafeStringDepth bounds the pre-scan in safeGoString; values nested
@@ -99,15 +154,68 @@ const maxSafeStringDepth = 100
 // that reaches itself, killing the process with an unrecoverable fatal
 // stack overflow. Values containing a cycle (or nested deeper than
 // maxSafeStringDepth) format as "<cyclic TYPE>" instead; all other values
-// format exactly as fmt.Sprint does.
+// format exactly as fmt.Sprint does. The scan is skipped entirely for
+// types that cannot hold a cycle (see typeCanCycle).
 func safeGoString(v reflect.Value) string {
 	if !v.IsValid() {
 		return "<invalid>"
 	}
-	if hasRefCycle(v, make(map[uintptr]bool), 0) {
+	if typeCanCycle(v.Type()) && hasRefCycle(v, make(map[uintptr]bool), 0) {
 		return fmt.Sprintf("<cyclic %s>", v.Type())
 	}
 	return fmt.Sprint(v.Interface())
+}
+
+// typeCanCycleCache memoizes typeCanCycle per reflect.Type; the set of
+// types a process converts is small and fixed, so this never grows
+// unboundedly.
+var typeCanCycleCache sync.Map // reflect.Type -> bool
+
+// typeCanCycle reports whether a value of type t can possibly contain a
+// reference cycle: that requires reaching an interface kind (which can hold
+// anything, including the value itself) or a recursive type definition
+// (e.g. type M map[string]M). For statically acyclic types like
+// map[string]int the cycle pre-scan in safeGoString is pure overhead and
+// is skipped.
+func typeCanCycle(t reflect.Type) bool {
+	if c, ok := typeCanCycleCache.Load(t); ok {
+		return c.(bool)
+	}
+	c := typeCanCycleWalk(t, nil)
+	typeCanCycleCache.Store(t, c)
+	return c
+}
+
+// typeCanCycleWalk is the uncached recursion behind typeCanCycle; onPath
+// tracks the types on the current descent so recursive type definitions
+// are detected (pass nil to start).
+func typeCanCycleWalk(t reflect.Type, onPath map[reflect.Type]bool) bool {
+	if onPath[t] {
+		return true // recursive type definition
+	}
+	switch t.Kind() {
+	case reflect.Interface:
+		return true
+	case reflect.Map, reflect.Slice, reflect.Array, reflect.Ptr, reflect.Struct:
+		if onPath == nil {
+			onPath = make(map[reflect.Type]bool)
+		}
+		onPath[t] = true
+		defer delete(onPath, t)
+		switch t.Kind() {
+		case reflect.Map:
+			return typeCanCycleWalk(t.Key(), onPath) || typeCanCycleWalk(t.Elem(), onPath)
+		case reflect.Slice, reflect.Array, reflect.Ptr:
+			return typeCanCycleWalk(t.Elem(), onPath)
+		case reflect.Struct:
+			for i := 0; i < t.NumField(); i++ {
+				if typeCanCycleWalk(t.Field(i).Type, onPath) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // hasRefCycle reports whether v reaches itself through maps, slices,

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	startime "go.starlark.net/lib/time"
@@ -102,14 +103,14 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	case reflect.Func:
 		return makeStarFn("fn", val, tagName), nil
 	case reflect.Map:
-		if err := checkCollectionElemTypes(val.Type(), nil); err != nil {
+		if err := checkCollectionElemTypesCached(val.Type()); err != nil {
 			return nil, err
 		}
 		return &GoMap{v: val, tag: tagName}, nil
 	case reflect.String:
 		return starlark.String(val.String()), nil
 	case reflect.Slice, reflect.Array:
-		if err := checkCollectionElemTypes(val.Type(), nil); err != nil {
+		if err := checkCollectionElemTypesCached(val.Type()); err != nil {
 			return nil, err
 		}
 		return &GoSlice{v: arrayToSlice(val), tag: tagName}, nil
@@ -132,6 +133,26 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	}
 
 	return nil, fmt.Errorf("type %T is not a supported starlark type", val.Interface())
+}
+
+// elemTypeCheckCache memoizes checkCollectionElemTypes per reflect.Type:
+// collections are wrapped on every element access, but the set of types a
+// process converts is small and fixed, so the cache never grows
+// unboundedly. The stored value is the (possibly nil) error.
+var elemTypeCheckCache sync.Map // reflect.Type -> error
+
+// checkCollectionElemTypesCached is the cached front of
+// checkCollectionElemTypes; use this on conversion hot paths.
+func checkCollectionElemTypesCached(t reflect.Type) error {
+	if v, ok := elemTypeCheckCache.Load(t); ok {
+		if v == nil {
+			return nil
+		}
+		return v.(error)
+	}
+	err := checkCollectionElemTypes(t, nil)
+	elemTypeCheckCache.Store(t, err)
+	return err
 }
 
 // checkCollectionElemTypes verifies that the key and element types of a map,

--- a/convert/order_test.go
+++ b/convert/order_test.go
@@ -73,6 +73,33 @@ func TestGoMapMixedKeyTypeOrder(t *testing.T) {
 	}
 }
 
+// TestGoMapKeyTieBreak verifies that keys of different concrete types with
+// equal rank and value (int8(5) vs int64(5)) still come out in a
+// deterministic order — ties break on the concrete type name.
+func TestGoMapKeyTieBreak(t *testing.T) {
+	var want []string
+	for run := 0; run < 20; run++ {
+		m := map[interface{}]interface{}{
+			int8(5):  "a",
+			int64(5): "b",
+			int32(5): "c",
+		}
+		var got []string
+		for _, k := range convert.NewGoMap(m).Keys() {
+			got = append(got, fmt.Sprintf("%T", convert.FromValue(k)))
+		}
+		if run == 0 {
+			want = got
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: key order changed: %v vs %v", run, got, want)
+			}
+		}
+	}
+}
+
 // TestMakeDictDeterministicOrder verifies MakeDict materializes Go map
 // entries into the Starlark dict in sorted key order (Starlark dicts
 // preserve insertion order, so this is script-visible).


### PR DESCRIPTION
## Why

New `convert/bench_test.go` (committed here) compared master against the pre-fix baseline `70b49d8` and showed the recent panic/determinism fixes added measurable overhead on conversion hot paths.

## Changes (no observable behavior change, except one determinism fix)

- `sortedMapKeys` extracts each key's sort key once up front (decorate–sort–undecorate) and sorts via a concrete `sort.Interface` — `sort.SliceStable`'s reflect-based swapping was measurably slower.
- The collection element-type pre-check is memoized per `reflect.Type` (`sync.Map`); collections are re-wrapped on every element access, and the set of types a process converts is small and fixed.
- `String()` skips the cycle pre-scan entirely for types that cannot hold a cycle (`typeCanCycle`, memoized): cycles require reaching an interface kind or a recursive type definition, so e.g. `map[string]int` pays nothing.
- **Determinism fix found while benchmarking**: keys of different concrete types with equal rank and value (`int8(5)` vs `int64(5)` in an interface-keyed map) tied and kept Go's random order; ties now break on the concrete type name, lazily (no cost unless a tie occurs). Pinned by `TestGoMapKeyTieBreak` (20 runs).

## Numbers (50-key map, darwin/arm64, median of 3)

| benchmark | before | after | pre-fix baseline |
|---|---|---|---|
| ToValueMap50 | 78ns | 38ns | 32ns |
| GoMapString50 | 9.3µs | 7.1µs | 7.5µs |
| GoSliceString1k | 33µs | 30µs | 30µs |
| GoMapKeys50 | 7.8µs | 6.9µs | 2.5µs* |

\* the remaining gap is the inherent cost of deterministic ordering (~80ns/key), paid only on materialization calls (keys/items/iteration), not on get/set.

## Tests

Full suite with `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker; behavior pinned by the existing order/safety tests plus the new tie-break test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)