### PR TITLE
fix: checked conversions at all three entry points

### DIFF
--- a/convert/call_test.go
+++ b/convert/call_test.go
@@ -442,13 +442,14 @@ func TestCallGoFunctionInStarlark(t *testing.T) {
 			wantErrExec: true,
 		},
 		{
-			name: "fuzzy func(string) int",
+			// integer arguments no longer fuzzy-match string parameters:
+			// the old behavior was Go's codepoint conversion (42 -> "*")
+			name: "int for string param is an error: func(string) int",
 			goFunc: func(name string) int {
 				return len(name)
 			},
-			codeSnippet:  `sl_value = go_func(42)`,
-			expectResult: int64(1),
-			wantEqual:    true,
+			codeSnippet: `sl_value = go_func(42)`,
+			wantErrExec: true,
 		},
 		{
 			name: "pointer as invalid argument: func(*string) string",

--- a/convert/checked_conv_test.go
+++ b/convert/checked_conv_test.go
@@ -85,6 +85,52 @@ func TestCheckedFuncArgs(t *testing.T) {
 	}
 }
 
+// TestCheckedUintAndEdgeSources covers the remaining numeric source
+// classes: huge Starlark ints arrive as uint64 (too big for int64), floats
+// can be NaN/negative, and huge uints must not fit smaller uints either.
+func TestCheckedUintAndEdgeSources(t *testing.T) {
+	var gotI8 int8
+	var gotU8 uint8
+	var gotU uint
+	var gotI int
+	var gotS string
+	var gotF32 float32
+	globals := map[string]interface{}{
+		"fnI8":  func(i int8) { gotI8 = i },
+		"fnU8":  func(u uint8) { gotU8 = u },
+		"fnU":   func(u uint) { gotU = u },
+		"fnI":   func(i int) { gotI = i },
+		"fnS":   func(s string) { gotS = s },
+		"fnF32": func(f float32) { gotF32 = f },
+	}
+
+	// 1e19 > MaxInt64: arrives as uint64
+	evalErr(t, `fnI8(10000000000000000000)`, globals, "out of range")
+	evalErr(t, `fnI(10000000000000000000)`, globals, "out of range")
+	evalErr(t, `fnU8(10000000000000000000)`, globals, "out of range")
+	evalErr(t, `fnS(10000000000000000000)`, globals, "cannot be converted")
+	// float sources into integer targets
+	evalErr(t, `fnU(3.9)`, globals, "would be truncated")
+	evalErr(t, `fnU(-1.0)`, globals, "out of range")
+	evalErr(t, `fnI(float("nan"))`, globals, "would be truncated")
+	evalErr(t, `fnI(float("inf"))`, globals, "would be truncated")
+	evalErr(t, `fnI8(1e30)`, globals, "out of range") // whole float, but far too large
+	if gotI8 != 0 || gotU8 != 0 || gotU != 0 || gotI != 0 || gotS != "" || gotF32 != 0 {
+		t.Fatalf("corrupted values leaked through: %d %d %d %d %q %g", gotI8, gotU8, gotU, gotI, gotS, gotF32)
+	}
+
+	// huge uint64 fits the wide targets
+	evalOK(t, `fnU(10000000000000000000)`, globals)
+	if gotU != 10000000000000000000 {
+		t.Fatalf("expected 1e19, got %d", gotU)
+	}
+	// whole floats fit unsigned targets
+	evalOK(t, `fnU8(200.0)`, globals)
+	if gotU8 != 200 {
+		t.Fatalf("expected 200, got %d", gotU8)
+	}
+}
+
 // TestCheckedNoneArgs verifies None stays valid for nullable parameter
 // types and is rejected for non-nullable ones (the two entry points used
 // to disagree: one zeroed, one errored).

--- a/convert/checked_conv_test.go
+++ b/convert/checked_conv_test.go
@@ -1,0 +1,190 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+)
+
+// Regression tests for checked conversions: the three conversion entry
+// points trusted reflect.ConvertibleTo blindly, which silently corrupted
+// values on the way into Go functions and collections:
+//
+//	fn(65)   -> func(string) received "A"  (Go codepoint conversion)
+//	fn(1000) -> func(int8)   received -24  (integer wrap-around)
+//	fn(3.9)  -> func(int)    received 3    (float truncation)
+//	fn(None) -> func(int)    received 0    (None silently zeroed)
+//
+// All four must be regular errors; lossless conversions must keep working.
+
+func evalErr(t *testing.T, code string, globals map[string]interface{}, want string) {
+	t.Helper()
+	_, err := starlight.Eval([]byte(code), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("%s: expected error containing %q, got %v", code, want, err)
+	}
+}
+
+func evalOK(t *testing.T, code string, globals map[string]interface{}) {
+	t.Helper()
+	if _, err := starlight.Eval([]byte(code), globals, nil); err != nil {
+		t.Fatalf("%s: unexpected error %v", code, err)
+	}
+}
+
+// TestCheckedFuncArgs verifies the silent corruptions through function
+// arguments are now errors, and lossless calls still work.
+func TestCheckedFuncArgs(t *testing.T) {
+	var gotS string
+	var gotI8 int8
+	var gotI int
+	var gotU uint
+	var gotF32 float32
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"fnS":    func(s string) { gotS = s },
+		"fnI8":   func(i int8) { gotI8 = i },
+		"fnI":    func(i int) { gotI = i },
+		"fnU":    func(u uint) { gotU = u },
+		"fnF32":  func(f float32) { gotF32 = f },
+	}
+
+	// silent corruption -> errors
+	evalErr(t, `fnS(65)`, globals, "cannot be converted")
+	evalErr(t, `fnI8(1000)`, globals, "out of range")
+	evalErr(t, `fnI(3.9)`, globals, "would be truncated")
+	evalErr(t, `fnU(-1)`, globals, "out of range")
+	evalErr(t, `fnI(None)`, globals, "non-nullable")
+	evalErr(t, `fnF32(3.5e108)`, globals, "out of range")
+	if gotS != "" || gotI8 != 0 || gotI != 0 || gotU != 0 || gotF32 != 0 {
+		t.Fatalf("corrupted values leaked through: %q %d %d %d %g", gotS, gotI8, gotI, gotU, gotF32)
+	}
+
+	// lossless conversions keep working
+	evalOK(t, `fnI8(100)`, globals)
+	if gotI8 != 100 {
+		t.Fatalf("expected 100, got %d", gotI8)
+	}
+	evalOK(t, `fnI(3.0)`, globals) // whole float is lossless
+	if gotI != 3 {
+		t.Fatalf("expected 3, got %d", gotI)
+	}
+	evalOK(t, `fnU(42)`, globals)
+	if gotU != 42 {
+		t.Fatalf("expected 42, got %d", gotU)
+	}
+	evalOK(t, `fnF32(1.5)`, globals)
+	if gotF32 != 1.5 {
+		t.Fatalf("expected 1.5, got %g", gotF32)
+	}
+	evalOK(t, `fnS("hi")`, globals)
+	if gotS != "hi" {
+		t.Fatalf("expected hi, got %q", gotS)
+	}
+}
+
+// TestCheckedNoneArgs verifies None stays valid for nullable parameter
+// types and is rejected for non-nullable ones (the two entry points used
+// to disagree: one zeroed, one errored).
+func TestCheckedNoneArgs(t *testing.T) {
+	var gotP *int
+	var calledP bool
+	var gotSl []int
+	var calledSl bool
+	globals := map[string]interface{}{
+		"fnP":  func(p *int) { gotP, calledP = p, true },
+		"fnSl": func(s []int) { gotSl, calledSl = s, true },
+	}
+	evalOK(t, `fnP(None)`, globals)
+	if !calledP || gotP != nil {
+		t.Fatalf("expected nil pointer call, got %v %v", calledP, gotP)
+	}
+	evalOK(t, `fnSl(None)`, globals)
+	if !calledSl || gotSl != nil {
+		t.Fatalf("expected nil slice call, got %v %v", calledSl, gotSl)
+	}
+}
+
+// TestCheckedCollectionWrites verifies the same checks guard writes into
+// wrapped Go collections (append/setkey go through tryConv).
+func TestCheckedCollectionWrites(t *testing.T) {
+	s8 := []int8{1}
+	m8 := map[string]int8{}
+	globals := map[string]interface{}{
+		"s8": s8,
+		"m8": m8,
+	}
+	evalErr(t, `s8.append(1000)`, globals, "out of range")
+	evalErr(t, `m8["a"] = 1000`, globals, "out of range")
+	evalErr(t, `m8["a"] = 3.9`, globals, "would be truncated")
+	if len(m8) != 0 {
+		t.Fatalf("expected map unchanged, got %v", m8)
+	}
+	evalOK(t, `m8["a"] = 100`, globals)
+	if m8["a"] != 100 {
+		t.Fatalf("expected 100, got %v", m8)
+	}
+}
+
+// TestCheckedVariadic verifies variadic arguments get the same checks.
+func TestCheckedVariadic(t *testing.T) {
+	var got []int8
+	globals := map[string]interface{}{
+		"fnV": func(vs ...int8) { got = vs },
+	}
+	evalErr(t, `fnV(1, 1000)`, globals, "out of range")
+	if got != nil {
+		t.Fatalf("corrupted variadic leaked through: %v", got)
+	}
+	evalOK(t, `fnV(1, 2, 3)`, globals)
+	if len(got) != 3 || got[2] != 3 {
+		t.Fatalf("expected [1 2 3], got %v", got)
+	}
+}
+
+// TestCheckedConvertMapSlice verifies the deep map/slice argument
+// conversion path (convertElemValue) applies the same checks.
+func TestCheckedConvertMapSlice(t *testing.T) {
+	var gotM map[string]int8
+	var gotS []int8
+	globals := map[string]interface{}{
+		"fnM": func(m map[string]int8) { gotM = m },
+		"fnS": func(s []int8) { gotS = s },
+	}
+	evalErr(t, `fnM({"a": 1000})`, globals, "out of range")
+	evalErr(t, `fnS([1, 1000])`, globals, "out of range")
+	if gotM != nil || gotS != nil {
+		t.Fatalf("corrupted values leaked through: %v %v", gotM, gotS)
+	}
+	evalOK(t, `fnM({"a": 100})`, globals)
+	if gotM["a"] != 100 {
+		t.Fatalf("expected 100, got %v", gotM)
+	}
+	evalOK(t, `fnS([1, 2])`, globals)
+	if len(gotS) != 2 {
+		t.Fatalf("expected [1 2], got %v", gotS)
+	}
+}
+
+// TestTryConvIntactForSafeConversions pins behaviors that must not change:
+// identical types, named types, and string/bytes conversions.
+func TestTryConvIntactForSafeConversions(t *testing.T) {
+	type myString string
+	var gotMy myString
+	var gotB []byte
+	globals := map[string]interface{}{
+		"fnMy": func(s myString) { gotMy = s },
+		"fnB":  func(b []byte) { gotB = b },
+	}
+	evalOK(t, `fnMy("hello")`, globals)
+	if gotMy != "hello" {
+		t.Fatalf("expected hello, got %q", gotMy)
+	}
+	evalOK(t, `fnB("bytes")`, globals)
+	if string(gotB) != "bytes" {
+		t.Fatalf("expected bytes, got %q", gotB)
+	}
+	_ = convert.FromValue // keep convert imported for symmetry with siblings
+}

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -4,6 +4,7 @@ package convert
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -765,16 +766,25 @@ func makeOut(out []reflect.Value, tagName string) (starlark.Value, error) {
 	return starlark.Tuple(res), err
 }
 
-// convertReflectValue converts a reflect.Value to a given type.
+// convertReflectValue converts a reflect.Value to a given type. Conversions
+// go through checkedConvert, so values that ConvertibleTo would silently
+// corrupt (codepoint conversion, wrap-around, truncation) are errors. An
+// invalid val (a Starlark None) is accepted only for nullable types, the
+// same policy tryConv applies (it used to be silently zeroed here).
 func convertReflectValue(val reflect.Value, argT reflect.Type) (reflect.Value, error) {
 	if !val.IsValid() {
-		return reflect.Zero(argT), nil
+		switch argT.Kind() {
+		case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Func:
+			return reflect.Zero(argT), nil
+		default:
+			return reflect.Value{}, fmt.Errorf("value of type None cannot be converted to non-nullable type %s", argT)
+		}
 	}
 	if val.Type().AssignableTo(argT) {
 		return val, nil
 	}
 	if val.Type().ConvertibleTo(argT) {
-		return val.Convert(argT), nil
+		return checkedConvert(val, argT)
 	}
 	if val.Kind() == reflect.Slice && argT.Kind() == reflect.Slice {
 		return convertSlice(val, argT)
@@ -796,9 +806,17 @@ func convertSlice(val reflect.Value, argT reflect.Type) (reflect.Value, error) {
 		if elem.Type().AssignableTo(argElem) {
 			newSlice.Index(i).Set(elem)
 		} else if elem.Type().ConvertibleTo(argElem) {
-			newSlice.Index(i).Set(elem.Convert(argElem))
+			cv, err := checkedConvert(elem, argElem)
+			if err != nil {
+				return reflect.Value{}, fmt.Errorf("slice element %d: %v", i, err)
+			}
+			newSlice.Index(i).Set(cv)
 		} else if elem.Elem().Type().ConvertibleTo(argElem) {
-			newSlice.Index(i).Set(elem.Elem().Convert(argElem))
+			cv, err := checkedConvert(elem.Elem(), argElem)
+			if err != nil {
+				return reflect.Value{}, fmt.Errorf("slice element %d: %v", i, err)
+			}
+			newSlice.Index(i).Set(cv)
 		} else {
 			return reflect.Value{}, fmt.Errorf("expected slice element type %v got %v", argElem, elem.Type())
 		}
@@ -832,17 +850,17 @@ func convertMap(val reflect.Value, argT reflect.Type) (reflect.Value, error) {
 
 func convertElemValue(val reflect.Value, targetType reflect.Type) (reflect.Value, error) {
 	if val.Type().AssignableTo(targetType) || val.Type().ConvertibleTo(targetType) {
-		return val.Convert(targetType), nil
+		return checkedConvert(val, targetType)
 	} else if val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
 		if val.IsNil() {
 			return reflect.Value{}, fmt.Errorf("nil value cannot be converted to type %v", targetType)
 		}
 		if val.Elem().Type().ConvertibleTo(targetType) {
-			return val.Elem().Convert(targetType), nil
+			return checkedConvert(val.Elem(), targetType)
 		} else if val.Type().Kind() == reflect.Interface {
 			unwrapped := val.Elem()
 			if unwrapped.Type().ConvertibleTo(targetType) {
-				return unwrapped.Convert(targetType), nil
+				return checkedConvert(unwrapped, targetType)
 			} else if sv, ok := unwrapped.Interface().(starlark.Value); ok {
 				// TODO: this path is not reachable in the current test, maybe we can remove it?
 				goVal := FromValue(sv)
@@ -901,11 +919,83 @@ func tryConv(v starlark.Value, t reflect.Type) (reflect.Value, error) {
 		}
 	}
 	out := reflect.ValueOf(FromValue(v))
-	if !out.Type().AssignableTo(t) {
-		if out.Type().ConvertibleTo(t) {
-			return out.Convert(t), nil
-		}
-		return reflect.Value{}, fmt.Errorf("value of type %s cannot be converted to type %s", out.Type(), t)
+	return checkedConvert(out, t)
+}
+
+// checkedConvert converts val to type t like reflect's Convert, but refuses
+// the conversions ConvertibleTo permits that silently corrupt the value on
+// the way through:
+//
+//   - integer -> string is Go's codepoint conversion (65 -> "A"), never
+//     what a script means;
+//   - numeric narrowing that overflows the target wraps around
+//     (1000 -> int8(-24));
+//   - float -> integer conversion truncates (3.9 -> 3); whole floats
+//     convert fine.
+//
+// Values already assignable to t pass through untouched.
+func checkedConvert(val reflect.Value, t reflect.Type) (reflect.Value, error) {
+	if val.Type().AssignableTo(t) {
+		return val, nil
 	}
-	return out, nil
+	if !val.Type().ConvertibleTo(t) {
+		return reflect.Value{}, fmt.Errorf("value of type %s cannot be converted to type %s", val.Type(), t)
+	}
+	zt := reflect.Zero(t)
+	switch t.Kind() {
+	case reflect.String:
+		switch val.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return reflect.Value{}, fmt.Errorf("value of type %s cannot be converted to type %s (integer to string would be a codepoint conversion)", val.Type(), t)
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		switch val.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			if zt.OverflowInt(val.Int()) {
+				return reflect.Value{}, fmt.Errorf("value %d out of range for type %s", val.Int(), t)
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			u := val.Uint()
+			if u > math.MaxInt64 || zt.OverflowInt(int64(u)) {
+				return reflect.Value{}, fmt.Errorf("value %d out of range for type %s", u, t)
+			}
+		case reflect.Float32, reflect.Float64:
+			f := val.Float()
+			if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+				return reflect.Value{}, fmt.Errorf("value %v would be truncated when converted to type %s", f, t)
+			}
+			if f < math.MinInt64 || f >= math.MaxInt64 || zt.OverflowInt(int64(f)) {
+				return reflect.Value{}, fmt.Errorf("value %v out of range for type %s", f, t)
+			}
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		switch val.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			i := val.Int()
+			if i < 0 || zt.OverflowUint(uint64(i)) {
+				return reflect.Value{}, fmt.Errorf("value %d out of range for type %s", i, t)
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			if zt.OverflowUint(val.Uint()) {
+				return reflect.Value{}, fmt.Errorf("value %d out of range for type %s", val.Uint(), t)
+			}
+		case reflect.Float32, reflect.Float64:
+			f := val.Float()
+			if math.IsNaN(f) || math.IsInf(f, 0) || f != math.Trunc(f) {
+				return reflect.Value{}, fmt.Errorf("value %v would be truncated when converted to type %s", f, t)
+			}
+			if f < 0 || f >= math.MaxUint64 || zt.OverflowUint(uint64(f)) {
+				return reflect.Value{}, fmt.Errorf("value %v out of range for type %s", f, t)
+			}
+		}
+	case reflect.Float32, reflect.Float64:
+		switch val.Kind() {
+		case reflect.Float32, reflect.Float64:
+			if zt.OverflowFloat(val.Float()) {
+				return reflect.Value{}, fmt.Errorf("value %v out of range for type %s", val.Float(), t)
+			}
+		}
+	}
+	return val.Convert(t), nil
 }

--- a/convert/conv_test.go
+++ b/convert/conv_test.go
@@ -279,11 +279,9 @@ mm = m
 	if exp := []interface{}{1, 2, 3, []interface{}{1, 2, 3}}; !reflect.DeepEqual(cnv["ss"], exp) {
 		t.Errorf("2 expected %v, got %v", exp, cnv["ss"])
 	}
-	// TODO: fix it
-	//if exp := map[interface{}]interface{}{"c": 3, "d": 4, "f": (map[interface{}]interface{})(nil)}; !reflect.DeepEqual(cnv["dd"], exp) {
-	//	t.Errorf("3 expected %#v, got %#v", exp, cnv["dd"])
-	//}
-	//t.Logf("converted results: %v", cnv)
+	if exp := map[interface{}]interface{}{"c": int64(3), "d": int64(4), "f": (map[interface{}]interface{})(nil)}; !reflect.DeepEqual(cnv["dd"], exp) {
+		t.Errorf("3 expected %#v, got %#v", exp, cnv["dd"])
+	}
 }
 
 func TestKwargs(t *testing.T) {


### PR DESCRIPTION
## Problem

The three conversion entry points (`convertReflectValue`, `tryConv`, `convertElemValue`, plus the `convertSlice`/`convertMap` element paths) trusted `reflect.ConvertibleTo` blindly, silently corrupting values on the way into Go functions and collections:

| script | parameter | received |
|---|---|---|
| `fn(65)` | `func(string)` | `"A"` (Go codepoint conversion) |
| `fn(1000)` | `func(int8)` | `-24` (integer wrap-around) |
| `fn(3.9)` | `func(int)` | `3` (float truncation) |
| `fn(None)` | `func(int)` | `0` (None silently zeroed) |

## Fix

All conversions go through a single checked core, `checkedConvert`, behind the existing entry points — **signatures unchanged**:

- integer → string conversions are refused (codepoint semantics are never what a script means)
- numeric narrowing is range-checked for ints, uints and floats (`OverflowInt/Uint/Float`)
- float → integer requires a whole number; `fn(3.0)` still converts
- None is accepted only for nullable parameter types, unifying the two policies that used to disagree (`tryConv` errored, `convertReflectValue` silently zeroed)

Assignable values pass through untouched; named-type / string↔bytes conversions are pinned unchanged by test.

## Behavior changes (intentional, were the bug)

- `fuzzy func(string) int` test pinned the codepoint behavior (`go_func(42)` → `"*"` → len 1) and now expects an error.
- The `TestAppendItself` assertion commented out with a `TODO: fix it` is restored — the self-referential dict converts correctly after the earlier key/recursion fixes (#37/#43).

## Tests

New `convert/checked_conv_test.go`: all four corruption classes at script level (function args, variadic, collection writes, deep map/slice args), None nullable/non-nullable policy, and pins for safe conversions. Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker; `SetGet`/`FromDict` benchmarks unchanged (~110ns / ~2.5µs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)