### PR TITLE
fix: five broken bridge contracts

### DIFF
--- a/convert/bridge_contract_test.go
+++ b/convert/bridge_contract_test.go
@@ -1,0 +1,192 @@
+package convert_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// Regression tests for five broken bridge contracts:
+//  1. wrapped Go functions silently swallowed keyword arguments, so
+//     fn(bogus=1) succeeded as if the kwarg had been applied;
+//  2. the error-return convention only matched the exact `error` interface
+//     type, so functions returning a concrete error type leaked it as a
+//     value instead of raising;
+//  3. MakeDict ignored SetKey errors, silently dropping entries whose key
+//     is unhashable on the Starlark side;
+//  4. pointer-receiver methods were invisible on addressable struct values
+//     (e.g. fields of a wrapped *struct);
+//  5. GoInterface's dir() omitted the synthetic to* conversion attributes
+//     that Attr actually supports, and double-listed methods for pointers.
+
+// TestKwargsRejected verifies wrapped Go functions reject keyword
+// arguments instead of silently dropping them.
+func TestKwargsRejected(t *testing.T) {
+	globals := map[string]interface{}{
+		"quote":  func(s string) string { return `"` + s + `"` },
+		"concat": func(ss ...string) string { return strings.Join(ss, "") },
+	}
+	for _, code := range []string{`v = quote("a", bogus=1)`, `v = concat("a", "b", bogus=1)`} {
+		_, err := starlight.Eval([]byte(code), globals, nil)
+		if err == nil || !strings.Contains(err.Error(), "unexpected keyword argument") {
+			t.Fatalf("%s: expected unexpected-keyword error, got %v", code, err)
+		}
+	}
+	// no kwargs still works
+	res, err := starlight.Eval([]byte(`v = quote("a")`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["v"] != `"a"` {
+		t.Fatalf("expected quoted a, got %v", res["v"])
+	}
+}
+
+type customErr struct {
+	msg string
+}
+
+func (e *customErr) Error() string { return e.msg }
+
+// TestConcreteErrorReturn verifies functions returning a concrete error
+// type raise in Starlark like `error`-typed returns do, and that a typed
+// nil error does not raise.
+func TestConcreteErrorReturn(t *testing.T) {
+	globals := map[string]interface{}{
+		"fail":   func() *customErr { return &customErr{msg: "boom"} },
+		"calc":   func(ok bool) (string, *customErr) { return "fine", nil },
+		"calc2":  func() (string, *customErr) { return "", &customErr{msg: "nope"} },
+		"legacy": func() (string, error) { return "v", nil },
+	}
+	_, err := starlight.Eval([]byte(`fail()`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected concrete error to raise, got %v", err)
+	}
+	res, err := starlight.Eval([]byte(`v = calc(True)`), globals, nil)
+	if err != nil {
+		t.Fatalf("typed nil error must not raise: %v", err)
+	}
+	if res["v"] != "fine" {
+		t.Fatalf("expected fine, got %v", res["v"])
+	}
+	_, err = starlight.Eval([]byte(`v = calc2()`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("expected concrete error to raise, got %v", err)
+	}
+	if res, err = starlight.Eval([]byte(`v = legacy()`), globals, nil); err != nil || res["v"] != "v" {
+		t.Fatalf("plain error convention broken: %v %v", res, err)
+	}
+}
+
+// TestMakeDictKeyError verifies MakeDict reports keys that are unhashable
+// on the Starlark side instead of silently dropping the entries.
+func TestMakeDictKeyError(t *testing.T) {
+	// [2]string is a comparable Go map key, but converts to a Starlark
+	// value (a slice wrapper) that is not hashable
+	m := map[[2]string]int{{"a", "b"}: 1}
+	if _, err := convert.MakeDict(m); err == nil {
+		t.Fatal("expected unhashable-key error from MakeDict, got nil")
+	}
+	// plain dicts still convert
+	v, err := convert.MakeDict(map[string]int{"a": 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.(*starlark.Dict).Len() != 1 {
+		t.Fatalf("expected 1 entry, got %v", v)
+	}
+}
+
+type innerCounter struct {
+	N int
+}
+
+func (c *innerCounter) Incr() { c.N++ }
+func (c innerCounter) Get() int {
+	return c.N
+}
+
+type outerHolder struct {
+	Inner innerCounter
+}
+
+// TestPointerMethodsOnAddressableValue verifies pointer-receiver methods
+// are reachable on addressable struct values, e.g. fields of a wrapped
+// pointer — and that their mutations are visible to the host.
+func TestPointerMethodsOnAddressableValue(t *testing.T) {
+	o := &outerHolder{}
+	globals := map[string]interface{}{"o": o}
+	code := []byte(`
+o.Inner.Incr()
+o.Inner.Incr()
+v = o.Inner.Get()
+`)
+	res, err := starlight.Eval(code, globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if o.Inner.N != 2 {
+		t.Fatalf("expected mutations visible on host (N=2), got %+v", o)
+	}
+	if res["v"] != int64(2) {
+		t.Fatalf("expected v=2, got %v", res["v"])
+	}
+}
+
+type loudInt int
+
+func (l loudInt) Doubled() int { return int(l) * 2 }
+
+// TestGoInterfaceDirHonest verifies dir() on a GoInterface lists exactly
+// what Attr supports: real methods plus the synthetic to* conversions,
+// without duplicates.
+func TestGoInterfaceDirHonest(t *testing.T) {
+	v, err := convert.ToValue(loudInt(21))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gi, ok := v.(*convert.GoInterface)
+	if !ok {
+		t.Fatalf("expected GoInterface, got %T", v)
+	}
+	names := gi.AttrNames()
+	seen := map[string]bool{}
+	for _, n := range names {
+		if seen[n] {
+			t.Fatalf("duplicate attr name %q in %v", n, names)
+		}
+		seen[n] = true
+	}
+	for _, want := range []string{"Doubled", "toInt", "toString", "toFloat", "toUint", "toBool"} {
+		if !seen[want] {
+			t.Fatalf("expected %q in AttrNames, got %v", want, names)
+		}
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Fatalf("expected sorted attr names, got %v", names)
+	}
+	// every listed name must actually resolve through Attr
+	for _, n := range names {
+		av, err := gi.Attr(n)
+		if err != nil || av == nil {
+			t.Fatalf("AttrNames lists %q but Attr returns (%v, %v)", n, av, err)
+		}
+	}
+	// and the synthetic conversion works from a script
+	globals := map[string]interface{}{"x": v, "assert": nil}
+	delete(globals, "assert")
+	res, err := starlight.Eval([]byte(`v = x.Doubled()
+i = x.toInt()`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["v"] != int64(42) || res["i"] != int64(21) {
+		t.Fatalf("expected 42/21, got %v", res)
+	}
+	_ = fmt.Sprint // silence unused import on some build tags
+}

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -382,7 +382,11 @@ func makeDictTag(val reflect.Value, tagName string) (starlark.Value, error) {
 			if err != nil {
 				return nil, err
 			}
-			dict.SetKey(vk, vv)
+			// SetKey fails for keys that are unhashable on the Starlark
+			// side; dropping the entry silently is data loss
+			if err := dict.SetKey(vk, vv); err != nil {
+				return nil, fmt.Errorf("dict key %s: %v", vk.String(), err)
+			}
 		}
 	}
 	return dict, nil
@@ -657,11 +661,14 @@ func makeStarFn(name string, gofn reflect.Value, tagName string) *starlark.Built
 			}
 		}()
 
+		if len(kwargs) > 0 {
+			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %q (wrapped Go functions accept positional arguments only)", name, kwargs[0][0])
+		}
 		if len(args) != gofn.Type().NumIn() {
 			return starlark.None, fmt.Errorf("expected %d args but got %d", gofn.Type().NumIn(), len(args))
 		}
 
-		// convert all the args, but kwargs are ignored
+		// convert all the args
 		vals := FromTuple(args)
 		rvs := make([]reflect.Value, 0, len(vals))
 		for i, v := range vals {
@@ -691,12 +698,15 @@ func makeVariadicStarFn(name string, gofn reflect.Value, tagName string) *starla
 			}
 		}()
 
+		if len(kwargs) > 0 {
+			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %q (wrapped Go functions accept positional arguments only)", name, kwargs[0][0])
+		}
 		minArgs := gofn.Type().NumIn() - 1
 		if len(args) < minArgs {
 			return starlark.None, fmt.Errorf("expected at least %d args but got %d", minArgs, len(args))
 		}
 
-		// convert all the args, but kwargs are ignored
+		// convert all the args
 		vals := FromTuple(args)
 		rvs := make([]reflect.Value, 0, len(args))
 
@@ -738,9 +748,17 @@ func makeOut(out []reflect.Value, tagName string) (starlark.Value, error) {
 	}
 	last := out[len(out)-1]
 	var err error
-	if last.Type() == errType {
-		if v := last.Interface(); v != nil {
-			err = v.(error)
+	// the error-return convention matches any type implementing error, not
+	// just the error interface itself: a concrete error type in the last
+	// position used to leak through as a regular value instead of raising
+	if last.Type() == errType || last.Type().Implements(errType) {
+		isNil := false
+		switch last.Kind() {
+		case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+			isNil = last.IsNil()
+		}
+		if !isNil {
+			err = last.Interface().(error)
 		}
 		out = out[:len(out)-1]
 	}

--- a/convert/interface.go
+++ b/convert/interface.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 
 	"go.starlark.net/starlark"
 )
@@ -61,34 +62,41 @@ func (g *GoInterface) Attr(name string) (starlark.Value, error) {
 	}
 
 	method := g.v.MethodByName(name)
-	if method.Kind() != reflect.Invalid {
+	if method.Kind() != reflect.Invalid && method.CanInterface() {
 		return makeStarFn(name, method, g.tag), nil
 	}
 	return nil, nil
 }
 
-// AttrNames returns the list of all fields and methods on this struct.
+// interfaceAttrNames are the synthetic conversion attributes every
+// GoInterface supports through Attr, in addition to the wrapped value's
+// own methods.
+var interfaceAttrNames = []string{"toBool", "toFloat", "toInt", "toString", "toUint"}
+
+// AttrNames returns the names Attr resolves for this value: the wrapped
+// value's methods plus the synthetic to* conversion attributes, sorted and
+// without duplicates.
 func (g *GoInterface) AttrNames() []string {
 	if !g.v.IsValid() {
 		return nil
 	}
 
-	count := g.v.NumMethod()
-	if g.v.Kind() == reflect.Ptr && !g.v.IsNil() {
-		count += g.v.Elem().NumMethod()
-	}
-
-	names := make([]string, 0, count)
+	names := make([]string, 0, g.v.NumMethod()+len(interfaceAttrNames))
+	names = append(names, interfaceAttrNames...)
+	// a pointer's method set already includes its element's methods, so a
+	// single pass over g.v covers both
 	for i := 0; i < g.v.NumMethod(); i++ {
 		names = append(names, g.v.Type().Method(i).Name)
 	}
-	if g.v.Kind() == reflect.Ptr && !g.v.IsNil() {
-		t := g.v.Elem().Type()
-		for i := 0; i < t.NumMethod(); i++ {
-			names = append(names, t.Method(i).Name)
+	sort.Strings(names)
+	// deduplicate (a method may shadow a synthetic name)
+	nn := names[:0]
+	for i, n := range names {
+		if i == 0 || n != names[i-1] {
+			nn = append(nn, n)
 		}
 	}
-	return names
+	return nn
 }
 
 // String returns the string representation of the value.

--- a/convert/struct.go
+++ b/convert/struct.go
@@ -102,7 +102,12 @@ func (g *GoStruct) Attr(name string) (starlark.Value, error) {
 	v := g.v
 	if g.v.Kind() == reflect.Ptr {
 		v = v.Elem()
-		method = g.v.MethodByName(name)
+	} else if g.v.CanAddr() {
+		// pointer-receiver methods are not in a struct value's method set;
+		// for addressable values (e.g. fields of a wrapped pointer) they
+		// are reachable through the address, and their mutations stay
+		// visible to the host
+		method = g.v.Addr().MethodByName(name)
 		if method.Kind() != reflect.Invalid && method.CanInterface() {
 			return makeStarFn(name, method, g.tag), nil
 		}
@@ -142,9 +147,15 @@ func (g *GoStruct) Attr(name string) (starlark.Value, error) {
 
 // AttrNames returns the list of all fields and methods on this struct.
 func (g *GoStruct) AttrNames() []string {
-	// count the number of methods and fields
+	// count the number of methods and fields; addressable struct values
+	// expose pointer-receiver methods too (see Attr), so list the pointer
+	// type's method set for them
 	v := g.v
-	count := v.NumMethod()
+	mv := v
+	if v.Kind() != reflect.Ptr && v.CanAddr() {
+		mv = v.Addr()
+	}
+	count := mv.NumMethod()
 	if v.Kind() == reflect.Ptr {
 		elem := v.Elem()
 		count += elem.NumField() + elem.NumMethod()
@@ -163,8 +174,8 @@ func (g *GoStruct) AttrNames() []string {
 	}
 
 	// check each methods and fields
-	for i := 0; i < v.NumMethod(); i++ {
-		names = append(names, v.Type().Method(i).Name)
+	for i := 0; i < mv.NumMethod(); i++ {
+		names = append(names, mv.Type().Method(i).Name)
 	}
 	if v.Kind() == reflect.Ptr {
 		t := v.Elem().Type()


### PR DESCRIPTION
## Problems and fixes

1. **Keyword arguments were silently swallowed** by wrapped Go functions — `fn(bogus=1)` succeeded as if the kwarg had been applied. Both `makeStarFn` and the variadic variant now reject kwargs with `unexpected keyword argument`.
2. **The error-return convention only matched the exact `error` interface type**: a concrete error type (`func() *MyErr`) in the last return position leaked through as a regular value instead of raising. Detection now uses `Implements(errType)` with a typed-nil guard (a nil `*MyErr` does not raise).
3. **`MakeDict` ignored `SetKey` errors**, silently dropping entries whose key is unhashable on the Starlark side (e.g. a comparable Go array key that wraps to an unhashable slice value). The error propagates now.
4. **Pointer-receiver methods were invisible on struct values.** For addressable values — e.g. fields of a wrapped `*struct` — they are now reachable through the address, and their mutations stay visible to the host (`o.Inner.Incr()` works and mutates `o.Inner`). `AttrNames` lists them accordingly. Unaddressable values intentionally keep Go's own semantics (no pointer methods) rather than silently operating on a copy.
5. **`GoInterface`'s `dir()` lied**: it omitted the synthetic `to*` conversion attributes that `Attr` supports, and double-listed methods for pointer values (a pointer's method set already includes its element's). `AttrNames` now mirrors `Attr` exactly — sorted, deduplicated — and `Attr` gained the missing `CanInterface` guard.

## Tests

New `convert/bridge_contract_test.go`: kwargs rejection (fixed and variadic), concrete-error raising + typed-nil non-raising + legacy `error` convention pin, `MakeDict` key-error, pointer-method mutation visibility through a wrapped parent, and a dir()/Attr consistency sweep (every listed name must resolve). Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)