### PR TITLE
feat: typed PanicError sentinel at the conversion boundary

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -16,6 +17,21 @@ import (
 
 func init() {
 	resolve.AllowSet = true // allow the 'set' built-in
+}
+
+// PanicError reports a panic recovered at the conversion boundary. The
+// conversion entry points are not supposed to panic; if this error
+// surfaces, it indicates a bug in starlight (or a misbehaving custom
+// type), and the captured stack identifies where the panic started.
+type PanicError struct {
+	Value interface{} // the recovered panic value
+	Stack []byte      // the goroutine stack captured at recovery
+}
+
+// Error implements the error interface. The message keeps the historic
+// "panic recovered" prefix and appends the captured stack.
+func (e *PanicError) Error() string {
+	return fmt.Sprintf("panic recovered: %v\n%s", e.Value, e.Stack)
 }
 
 // ToValue attempts to convert the given value to a starlark.Value.
@@ -51,7 +67,7 @@ func hasMethods(val reflect.Value) bool {
 func toValue(val reflect.Value, tagName string) (result starlark.Value, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("panic recovered: %v", r)
+			err = &PanicError{Value: r, Stack: debug.Stack()}
 		}
 	}()
 

--- a/convert/panic_sentinel_test.go
+++ b/convert/panic_sentinel_test.go
@@ -1,0 +1,41 @@
+package convert
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestToValuePanicSentinel verifies the conversion boundary's recover
+// produces a typed *PanicError carrying the recovered value and the stack
+// where the panic started, instead of a bare message that hides the
+// origin. The panic is provoked through reflect: reading an unexported
+// field yields a value whose Interface() panics.
+func TestToValuePanicSentinel(t *testing.T) {
+	type hidden struct {
+		secret string //nolint:unused // read via reflect to provoke the panic
+	}
+	rv := reflect.ValueOf(hidden{secret: "x"}).Field(0)
+	if rv.CanInterface() {
+		t.Fatal("test setup broken: expected an unexported field value")
+	}
+
+	v, err := toValue(rv, "")
+	if err == nil {
+		t.Fatalf("expected an error, got value %v", v)
+	}
+	var pe *PanicError
+	if !errors.As(err, &pe) {
+		t.Fatalf("expected *PanicError, got %T: %v", err, err)
+	}
+	if pe.Value == nil || len(pe.Stack) == 0 {
+		t.Fatalf("expected recovered value and stack, got %+v", pe)
+	}
+	if !strings.Contains(err.Error(), "panic recovered") {
+		t.Fatalf("expected historic message prefix, got %q", err.Error())
+	}
+	if !strings.Contains(string(pe.Stack), "toValue") {
+		t.Fatalf("expected stack to identify the conversion frame, got:\n%s", pe.Stack)
+	}
+}


### PR DESCRIPTION
## Why

`toValue`'s blanket recover flattened every escaped panic into a bare `panic recovered: ...` string, hiding where the panic started. With the known panic sources now fixed at their origins (#37, #41), the recover is downgraded to a diagnosable sentinel — deliberately in a separate change from the source fixes, so each is verifiable on its own.

## Changes

- New `*PanicError` carries the recovered value and the goroutine stack captured at recovery; hosts can detect it via `errors.As`.
- The message keeps the historic `panic recovered` prefix and appends the stack.
- The recover itself **stays** — it remains the last line of defense against bugs and misbehaving custom types.

## Tests

White-box test provokes a real panic through reflect (unexported field's `Interface()`), asserts the typed sentinel, the preserved message prefix, and that the stack identifies the conversion frame. Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)