### PR TITLE
fix: bidirectional time.Duration mapping and Int ladder contract

### DIFF
--- a/convert/common.go
+++ b/convert/common.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"time"
 )
 
 // DoNotCompare is an embedded zero-sized struct used to disallow comparison operations (== and !=) on the containing struct.
@@ -16,6 +17,7 @@ var (
 	errType        = reflect.TypeOf((*error)(nil)).Elem()
 	emptyIfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
 	byteType       = reflect.TypeOf(byte(0))
+	durationType   = reflect.TypeOf(time.Duration(0))
 )
 
 // sortedMapKeys returns the keys of the given map value in a deterministic

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -76,6 +76,12 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 			// let Starlark values pass through, no conversion needed
 			return val.Interface().(starlark.Value), nil
 		}
+		// time.Duration maps to the standard Starlark time.duration, the
+		// mirror of the FromValue case below; without this it would be
+		// grabbed by the method check and wrapped as an opaque interface
+		if val.Type() == durationType {
+			return startime.Duration(val.Interface().(time.Duration)), nil
+		}
 		if hasMethods(val) {
 			// this handles all basic types with methods (numbers, strings, booleans)
 			ifc, ok := makeGoInterface(val)
@@ -204,6 +210,11 @@ func checkCollectionElemTypes(t reflect.Type, visited map[reflect.Type]bool) err
 }
 
 // FromValue converts a starlark value to a go value.
+//
+// Integer contract: a starlark.Int converts down a fixed ladder — int64 if
+// the value fits, else uint64 if it fits, else *math/big.Int. The Go type
+// of a round-tripped integer therefore depends on its magnitude and is not
+// guaranteed to be identical to what was originally converted in.
 func FromValue(v starlark.Value) interface{} {
 	return fromValue(v, nil)
 }
@@ -220,7 +231,8 @@ func fromValue(v starlark.Value, visited map[uintptr]bool) interface{} {
 	case starlark.Bool:
 		return bool(v)
 	case starlark.Int:
-		// starlark ints can be signed or unsigned
+		// the integer ladder documented on FromValue:
+		// int64 -> uint64 -> *big.Int
 		if i, ok := v.Int64(); ok {
 			return i
 		}
@@ -228,8 +240,6 @@ func fromValue(v starlark.Value, visited map[uintptr]bool) interface{} {
 			return i
 		}
 		return v.BigInt()
-		// buh... maybe > maxint64?  Dunno
-		// panic(fmt.Errorf("can't convert starlark.Int %v to int", v))
 	case starlark.Float:
 		return float64(v)
 	case starlark.String:
@@ -248,6 +258,8 @@ func fromValue(v starlark.Value, visited map[uintptr]bool) interface{} {
 		return nil
 	case startime.Time:
 		return time.Time(v)
+	case startime.Duration:
+		return time.Duration(v)
 	case *GoStruct:
 		return v.v.Interface()
 	case *GoInterface:

--- a/convert/timeval_test.go
+++ b/convert/timeval_test.go
@@ -1,0 +1,99 @@
+package convert_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	startime "go.starlark.net/lib/time"
+	"go.starlark.net/starlark"
+)
+
+// TestDurationSymmetry verifies time.Duration maps bidirectionally to the
+// standard Starlark time.duration. It used to convert one way only: into
+// an opaque interface wrapper that scripts could not use as a duration,
+// while time.duration values coming back were never unwrapped.
+func TestDurationSymmetry(t *testing.T) {
+	d := 90 * time.Second
+
+	v, err := convert.ToValue(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sd, ok := v.(startime.Duration)
+	if !ok {
+		t.Fatalf("expected startime.Duration, got %T", v)
+	}
+	if time.Duration(sd) != d {
+		t.Fatalf("expected %v, got %v", d, time.Duration(sd))
+	}
+
+	back := convert.FromValue(v)
+	gd, ok := back.(time.Duration)
+	if !ok || gd != d {
+		t.Fatalf("expected round-trip %v, got %v (%T)", d, back, back)
+	}
+
+	// script-visible: it is a real time.duration, with duration semantics
+	globals := map[string]interface{}{"d": d}
+	res, err := starlight.Eval([]byte(`
+t = type(d)
+double = d + d
+seconds = d.seconds
+`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["t"] != "time.duration" {
+		t.Fatalf("expected time.duration, got %v", res["t"])
+	}
+	if dd, ok := res["double"].(time.Duration); !ok || dd != 3*time.Minute {
+		t.Fatalf("expected 3m, got %v (%T)", res["double"], res["double"])
+	}
+	if res["seconds"] != float64(90) {
+		t.Fatalf("expected 90 seconds, got %v", res["seconds"])
+	}
+
+	// duration arguments convert back for Go functions
+	var got time.Duration
+	globals2 := map[string]interface{}{
+		"d":   d,
+		"fnD": func(in time.Duration) { got = in },
+	}
+	if _, err := starlight.Eval([]byte(`fnD(d)`), globals2, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got != d {
+		t.Fatalf("expected %v, got %v", d, got)
+	}
+}
+
+// TestIntLadderContract pins the documented FromValue integer ladder:
+// int64 if it fits, else uint64, else *big.Int.
+func TestIntLadderContract(t *testing.T) {
+	small := convert.FromValue(starlark.MakeInt(42))
+	if v, ok := small.(int64); !ok || v != 42 {
+		t.Fatalf("expected int64 42, got %v (%T)", small, small)
+	}
+
+	negative := convert.FromValue(starlark.MakeInt(-42))
+	if v, ok := negative.(int64); !ok || v != -42 {
+		t.Fatalf("expected int64 -42, got %v (%T)", negative, negative)
+	}
+
+	wide := convert.FromValue(starlark.MakeUint64(10000000000000000000)) // > MaxInt64
+	if v, ok := wide.(uint64); !ok || v != 10000000000000000000 {
+		t.Fatalf("expected uint64 1e19, got %v (%T)", wide, wide)
+	}
+
+	huge, ok := new(big.Int).SetString("36893488147419103232", 10) // 2^65
+	if !ok {
+		t.Fatal("bad big literal")
+	}
+	b := convert.FromValue(starlark.MakeBigInt(huge))
+	if v, ok := b.(*big.Int); !ok || v.Cmp(huge) != 0 {
+		t.Fatalf("expected *big.Int 2^65, got %v (%T)", b, b)
+	}
+}


### PR DESCRIPTION
## Problem

- `time.Duration` converted **one way only**: the method check grabbed it before any special-casing and wrapped it as an opaque `starlight_interface<time.Duration>` that scripts could not use as a duration; `time.duration` values coming back from scripts were never unwrapped back to `time.Duration`.
- `FromValue`'s integer ladder (`int64` → `uint64` → `*big.Int`) was undocumented, so the non-identity round-trip for large integers was a surprise instead of a contract.

## Fix

- `time.Duration` ↔ Starlark `time.duration` bidirectional mapping, mirroring the existing `time.Time` ↔ `time.time` special case.
- The integer ladder is now a documented contract on `FromValue` (and the in-code comment explains the ladder instead of the previous `buh... Dunno`).

## ⚠️ Behavior change

Hosts that previously received `starlight_interface<time.Duration>` (or scripts that saw that type) now get real `time.duration` values with duration semantics — arithmetic, `.seconds`, comparisons. This is the documented intent; flagged here as the changelog note.

## Tests

`TestDurationSymmetry`: Go↔Starlark round-trip, script-level `type()`/arithmetic/`.seconds`, and duration arguments into Go functions. `TestIntLadderContract`: pins all three ladder rungs (int64 / uint64 / `*big.Int`). Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)