### PR TITLE
fix: unwrap empty interfaces to their dynamic values

### DIFF
--- a/convert/call_test.go
+++ b/convert/call_test.go
@@ -160,7 +160,8 @@ test()
 			name:        "slice of interface",
 			goValue:     []interface{}{123, "world"},
 			codeSnippet: `exp = [123, "world"]` + codeCompareList,
-			wantErrExec: true, // for []interface{}, convert to GoSlice+GoInterface
+			// empty-interface elements unwrap to their dynamic values now,
+			// so the element comparison succeeds
 		},
 		{
 			name:        "complex slice of interface",
@@ -187,7 +188,8 @@ test()
 			name:        "array of interface",
 			goValue:     [2]interface{}{123, "world"},
 			codeSnippet: `exp = [123, "world"]` + codeCompareList,
-			wantErrExec: true, // for [2]interface{}, convert to GoSlice+GoInterface
+			// empty-interface elements unwrap to their dynamic values now,
+			// so the element comparison succeeds
 		},
 		{
 			name:        "complex array of interface",
@@ -1022,8 +1024,11 @@ out = pn
 			checkEqual: func(_ *personStruct, m map[string]interface{}) error {
 				if v, ok := m["foo"]; !ok {
 					return fmt.Errorf(`expected "foo" to be in globals, but not found`)
-				} else if n, ok := v.(int16); !ok {
-					return fmt.Errorf(`expected "foo" to be an int16, but got %T`, v)
+				} else if n, ok := v.(int64); !ok {
+					// empty-interface map elements unwrap to Starlark values,
+					// so the number round-trips as int64 (the FromValue ladder),
+					// not the original int16
+					return fmt.Errorf(`expected "foo" to be an int64, but got %T`, v)
 				} else if n != 12345 {
 					return fmt.Errorf(`expected "foo" to be 12345, but got %v`, n)
 				}

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -145,12 +145,18 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 		}
 		return &GoStruct{v: val, tag: tagName}, nil
 	case reflect.Interface:
+		// unwrap empty interfaces to their dynamic value: JSON-shaped data
+		// (map[string]interface{}, []interface{}) was unusable otherwise,
+		// since the opaque wrapper supports no comparison or arithmetic
+		// (m["a"] == 1 was False, m["a"] + 1 failed). Interfaces with
+		// methods keep the wrapper, which exposes those methods.
+		if val.Type().NumMethod() == 0 {
+			if val.IsNil() {
+				return starlark.None, nil
+			}
+			return toValue(val.Elem(), tagName)
+		}
 		return &GoInterface{v: val, tag: tagName}, nil
-		//if innerVal, ok := val.Interface().(interface{}); ok {
-		//	return ToValueWithTag(innerVal, tagName)
-		//} else {
-		//	return &GoInterface{v: val, tag: tagName}, nil
-		//}
 	case reflect.Invalid:
 		return starlark.None, nil
 	}
@@ -402,11 +408,11 @@ func makeDictTag(val reflect.Value, tagName string) (starlark.Value, error) {
 		// deterministic key order: Starlark dicts preserve insertion order,
 		// so the random order of MapKeys would be script-visible
 		for _, k := range sortedMapKeys(val) {
-			vk, err := adjustedToValue(k, tagName)
+			vk, err := toValue(k, tagName)
 			if err != nil {
 				return nil, err
 			}
-			vv, err := adjustedToValue(val.MapIndex(k), tagName)
+			vv, err := toValue(val.MapIndex(k), tagName)
 			if err != nil {
 				return nil, err
 			}
@@ -418,14 +424,6 @@ func makeDictTag(val reflect.Value, tagName string) (starlark.Value, error) {
 		}
 	}
 	return dict, nil
-}
-
-// Helper method that checks the input value for interface{} and adjusts the conversion accordingly.
-func adjustedToValue(val reflect.Value, tagName string) (starlark.Value, error) {
-	if val.Kind() == reflect.Interface && val.NumMethod() == 0 && val.Elem().IsValid() {
-		val = val.Elem()
-	}
-	return toValue(val, tagName)
 }
 
 // hashableGoValue converts a Starlark value into a Go value whose dynamic

--- a/convert/order_test.go
+++ b/convert/order_test.go
@@ -61,8 +61,9 @@ func TestGoMapMixedKeyTypeOrder(t *testing.T) {
 		got = append(got, k.String())
 	}
 	// bool < int < uint < float < string; within a rank, by value
-	// (interface-typed keys come out wrapped, hence the plain formatting)
-	want := []string{"false", "true", "5", "7", "9", "2.5", "a", "b"}
+	// (interface-typed keys unwrap to Starlark values, hence the Starlark
+	// formatting: capitalized bools, quoted strings)
+	want := []string{"False", "True", "5", "7", "9", "2.5", `"a"`, `"b"`}
 	if len(got) != len(want) {
 		t.Fatalf("expected %v, got %v", want, got)
 	}

--- a/convert/unwrap_test.go
+++ b/convert/unwrap_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
 )
 
 // Regression tests for empty-interface unwrapping: JSON-shaped data
@@ -67,4 +68,44 @@ assert.Eq(e.Error(), "boom")
 		t.Fatal(err)
 	}
 	_ = errors.New // keep errors imported alongside the error-shaped fixture
+}
+
+// TestGoInterfaceWrapperBasics pins the wrapper's value semantics directly:
+// printable, truthy, unhashable, and freezable as a no-op.
+func TestGoInterfaceWrapperBasics(t *testing.T) {
+	m := map[string]error{"e": wrappedError{msg: "boom"}}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+e = m["e"]
+assert.Eq(str(e), "boom")
+assert.Eq(bool(e), True)
+d = {}
+ok = "no error"
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	// unhashable: using the wrapper as a dict key must error, not panic
+	_, err := starlight.Eval([]byte(`d = {m["e"]: 1}`), globals, nil)
+	if err == nil {
+		t.Fatal("expected unhashable error for wrapper as dict key")
+	}
+	// Freeze is a documented no-op (no write path) and must not affect use
+	v, err := convert.ToValue(loudInt(3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v.Freeze()
+	if v.Truth() != true {
+		t.Fatalf("expected truthy wrapper after freeze")
+	}
+	if _, err := v.(*convert.GoInterface).Hash(); err == nil {
+		t.Fatal("expected hash error for interface wrapper")
+	}
+	if s := v.String(); s != "3" {
+		t.Fatalf("expected 3, got %q", s)
+	}
 }

--- a/convert/unwrap_test.go
+++ b/convert/unwrap_test.go
@@ -1,0 +1,70 @@
+package convert_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/1set/starlight"
+)
+
+// Regression tests for empty-interface unwrapping: JSON-shaped data
+// (map[string]interface{}, []interface{}) used to convert its elements into
+// opaque interface wrappers, so m["a"] == 1 was False, m["a"] + 1 failed
+// with an unknown binary op, and type() reported starlight_interface<int>.
+
+// TestJSONShapedDataUsable verifies elements of empty-interface collections
+// behave as native Starlark values.
+func TestJSONShapedDataUsable(t *testing.T) {
+	m := map[string]interface{}{
+		"a": 1,
+		"s": "x",
+		"f": 2.5,
+		"b": true,
+		"n": nil,
+		"l": []interface{}{1, "two", 3.0},
+		"d": map[string]interface{}{"inner": 42},
+	}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+assert.Eq(m["a"] == 1, True)
+assert.Eq(m["a"] + 1, 2)
+assert.Eq(type(m["a"]), "int")
+assert.Eq(m["s"] + "!", "x!")
+assert.Eq(m["f"] * 2, 5.0)
+assert.Eq(m["b"], True)
+assert.Eq(m["n"], None)
+assert.Eq(m["l"][1], "two")
+assert.Eq(m["d"]["inner"] + 0, 42)
+total = m["a"] + m["l"][0]
+assert.Eq(total, 2)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type wrappedError struct{ msg string }
+
+func (w wrappedError) Error() string { return w.msg }
+
+// TestNonEmptyInterfaceKeepsWrapper verifies interfaces with methods keep
+// the GoInterface wrapper, which is what exposes those methods.
+func TestNonEmptyInterfaceKeepsWrapper(t *testing.T) {
+	m := map[string]error{"e": wrappedError{msg: "boom"}}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+e = m["e"]
+assert.Eq(type(e).startswith("starlight_"), True)
+assert.Eq(e.Error(), "boom")
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+	_ = errors.New // keep errors imported alongside the error-shaped fixture
+}

--- a/convert/value_test.go
+++ b/convert/value_test.go
@@ -1046,7 +1046,8 @@ print(type(r), dir(r))
 assert.Eq(type(r), "starlight_struct<*strings.Reader>")
 
 s = data["S"]
-assert.Eq(type(s), "starlight_interface<<nil>>")
+assert.Eq(type(s), "NoneType")
+assert.Eq(s, None)
 
 t = data["T"]
 assert.Eq(type(t), "starlight_struct<convert_test.mockStr>")


### PR DESCRIPTION
## Problem

Elements of empty-interface collections (`map[string]interface{}`, `[]interface{}` — i.e. JSON-shaped data) converted into opaque interface wrappers:

```python
m["a"] == 1    # False
m["a"] + 1     # unknown binary op
type(m["a"])  # starlight_interface<int>
```

The data was effectively unusable from scripts.

## Fix

`toValue` unwraps interface values **with no methods** to their dynamic value (recursively through the normal conversion); a nil empty interface becomes `None`. Interfaces **with methods** keep the `GoInterface` wrapper — that wrapper is what exposes the methods. The dead commented-out attempt at this and the now-subsumed `adjustedToValue` helper are removed.

## ⚠️ Behavior changes (the documented intent)

- Scripts see native Starlark values instead of `starlight_interface` wrappers for empty-interface elements; comparisons and arithmetic work.
- Nil empty interfaces are `None` (was `starlight_interface<<nil>>`).
- Numeric dynamic types round-trip through the `FromValue` ladder (an `int16` element comes back `int64`) instead of preserving the exact Go type inside a wrapper.

Four old tests pinned the wrapper behavior (two of them with `wantErrExec: true` comments acknowledging the broken comparison) and are updated accordingly.

## Tests

New `convert/unwrap_test.go`: JSON-shaped usability sweep (comparison, arithmetic, type(), nesting, None) and a pin that method-bearing interfaces keep their wrapper and methods. Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)