### PR TITLE
fix: stop mutating process-global dialect flags on import

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -92,7 +92,7 @@ func (c *cache) doLoad(cc *cycleChecker, module string) (starlark.StringDict, er
 	if err != nil {
 		return nil, err
 	}
-	return starlark.ExecFile(thread, module, b, c.globals)
+	return starlark.ExecFileOptions(dialectOptions, thread, module, b, c.globals)
 }
 
 // -- concurrent cycle checking --

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -11,13 +11,8 @@ import (
 	"time"
 
 	startime "go.starlark.net/lib/time"
-	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
 )
-
-func init() {
-	resolve.AllowSet = true // allow the 'set' built-in
-}
 
 // PanicError reports a panic recovered at the conversion boundary. The
 // conversion entry points are not supposed to panic; if this error

--- a/convert/conv_test.go
+++ b/convert/conv_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 func TestMakeTuple(t *testing.T) {
@@ -59,7 +60,7 @@ t2d = type(tuple_has[3])
 		"t2c": starlark.String("bool"),
 		"t2d": starlark.String("float"),
 	}
-	res, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", []byte(code), globals)
+	res, err := starlark.ExecFileOptions(testFileOptions, &starlark.Thread{}, "foo.star", []byte(code), globals)
 	if err != nil {
 		t.Errorf("unexpected error to exec: %v", err)
 		return
@@ -80,7 +81,7 @@ t2 = ("a", 1, True, 0.1)
 		"t1": {int64(10)},
 		"t2": {"a", int64(1), true, 0.1},
 	}
-	res, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", []byte(code), nil)
+	res, err := starlark.ExecFileOptions(testFileOptions, &starlark.Thread{}, "foo.star", []byte(code), nil)
 	if err != nil {
 		t.Errorf("unexpected error to exec: %v", err)
 		return
@@ -144,7 +145,7 @@ t2d = type(list_has[3])
 		"t2c": starlark.String("bool"),
 		"t2d": starlark.String("float"),
 	}
-	res, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", []byte(code), globals)
+	res, err := starlark.ExecFileOptions(testFileOptions, &starlark.Thread{}, "foo.star", []byte(code), globals)
 	if err != nil {
 		t.Errorf("unexpected error to exec: %v", err)
 		return
@@ -227,7 +228,7 @@ a = all([x in set_has for x in ["a", 1, True, 0.1]])
 		"t2": starlark.String("set"),
 		"a":  starlark.True,
 	}
-	res, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", []byte(code), globals)
+	res, err := starlark.ExecFileOptions(testFileOptions, &starlark.Thread{}, "foo.star", []byte(code), globals)
 	if err != nil {
 		t.Errorf("unexpected error to exec: %v", err)
 		return
@@ -236,6 +237,10 @@ a = all([x in set_has for x in ["a", 1, True, 0.1]])
 		t.Errorf("expected %v, got %v", expRes, res)
 	}
 }
+
+// testFileOptions is the dialect used by white-box tests that compile
+// scripts directly: the standard language plus the 'set' built-in.
+var testFileOptions = &syntax.FileOptions{Set: true}
 
 func TestAppendItself(t *testing.T) {
 	l, _ := MakeList([]interface{}{4, 5, 6})
@@ -267,7 +272,7 @@ m["e"] = m
 # print("map", m)
 mm = m
 `
-	res, err := starlark.ExecFile(&starlark.Thread{}, "foo.star", []byte(code), globals)
+	res, err := starlark.ExecFileOptions(testFileOptions, &starlark.Thread{}, "foo.star", []byte(code), globals)
 	if err != nil {
 		t.Errorf("0 unexpected error to exec: %v", err)
 		return
@@ -310,7 +315,7 @@ func("a", 1, foo=1, bar=2)
 	globals := map[string]starlark.Value{
 		"func": starlark.NewBuiltin("func", fn),
 	}
-	_, err := starlark.ExecFile(thread, "foo.star", data, globals)
+	_, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, globals)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +354,7 @@ b = 0.1
 	envs := map[string]starlark.Value{
 		"boo": skyf,
 	}
-	globals, err := starlark.ExecFile(thread, "foo.star", data, envs)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, envs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +375,7 @@ func verifyTestStructValues(t *testing.T, v starlark.Value, script string) {
 	}
 
 	// read the value
-	globals, err := starlark.ExecFile(thread, "foo.star", code, envs)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", code, envs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -572,7 +577,7 @@ phone = contact.phone
 	}
 
 	// read the value
-	globals, err := starlark.ExecFile(thread, "foo.star", code, envs)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", code, envs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -589,7 +594,7 @@ phone = contact.phone
 contact.Name = "alice"
 contact.phone = "456"
 `)
-	globals, err = starlark.ExecFile(thread, "foo.star", code, envs)
+	globals, err = starlark.ExecFileOptions(testFileOptions, thread, "foo.star", code, envs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/convert/func_test.go
+++ b/convert/func_test.go
@@ -9,7 +9,13 @@ import (
 	"github.com/1set/starlight"
 	"github.com/1set/starlight/convert"
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
+
+// testFileOptions is the dialect used by tests that compile scripts
+// directly: the standard language plus the 'set' built-in, matching what
+// the starlight entry points pass explicitly.
+var testFileOptions = &syntax.FileOptions{Set: true}
 
 // Helper function to execute a Starlark script with given global functions and data
 func execStarlark(script string, envs map[string]starlark.Value) (map[string]interface{}, error) {
@@ -18,7 +24,9 @@ func execStarlark(script string, envs map[string]starlark.Value) (map[string]int
 	}
 
 	data := []byte(script)
-	globals, err := starlark.ExecFile(thread, "foo.star", data, envs)
+	// compile with the same dialect starlight uses (standard + set),
+	// passed explicitly instead of relying on process-global flags
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, envs)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +87,7 @@ a = boo("starlight")
 	globals := map[string]starlark.Value{
 		"boo": skyf,
 	}
-	globals, err := starlark.ExecFile(thread, "foo.star", data, globals)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, globals)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +318,7 @@ b = 0.1
 	globals := map[string]starlark.Value{
 		"boo": skyf,
 	}
-	globals, err := starlark.ExecFile(thread, "foo.star", data, globals)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, globals)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +371,7 @@ b = 0.1
 	globals := map[string]starlark.Value{
 		"boo": skyf,
 	}
-	globals, err := starlark.ExecFile(thread, "foo.star", data, globals)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "foo.star", data, globals)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +663,7 @@ func TestMakeStarFnArgumentType(t *testing.T) {
 				globals["val"] = sv
 			}
 
-			_, err := starlark.ExecFile(thread, "script.star", script, globals)
+			_, err := starlark.ExecFileOptions(testFileOptions, thread, "script.star", script, globals)
 			if tc.wantErr && err == nil {
 				t.Errorf("Expected error, but got none")
 			} else if !tc.wantErr && err != nil {

--- a/convert/value_test.go
+++ b/convert/value_test.go
@@ -461,7 +461,7 @@ def double(x):
 	return x*2
 `
 	thread := &starlark.Thread{Name: "test"}
-	globals, err := starlark.ExecFile(thread, "mock.star", code, nil)
+	globals, err := starlark.ExecFileOptions(testFileOptions, thread, "mock.star", code, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,0 +1,52 @@
+package starlight
+
+import (
+	"testing"
+
+	"go.starlark.net/resolve"
+)
+
+// TestNoGlobalDialectMutation verifies that importing starlight (and,
+// transitively, convert) no longer mutates the process-global resolve
+// flags: the dialect is passed explicitly to every compile/exec call.
+// Before, any import of these packages rewrote the dialect for every other
+// Starlark user in the same process.
+func TestNoGlobalDialectMutation(t *testing.T) {
+	if resolve.AllowSet {
+		t.Fatal("resolve.AllowSet was mutated by import")
+	}
+}
+
+// TestDialectCapabilities verifies the starlight entry points still compile
+// the full dialect (set built-in plus the standard nested def / lambda /
+// float / bitwise features) without the global flags.
+func TestDialectCapabilities(t *testing.T) {
+	res, err := Eval([]byte(`
+s = set([1, 2, 3])
+n = len(s)
+f = (lambda x: x * 2)(21)
+fl = 1.5 * 2
+b = 6 & 3
+
+def outer():
+    def inner():
+        return 1
+    return inner()
+
+d = outer()
+`), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for k, want := range map[string]interface{}{
+		"n":  int64(3),
+		"f":  int64(42),
+		"fl": float64(3),
+		"b":  int64(2),
+		"d":  int64(1),
+	} {
+		if res[k] != want {
+			t.Fatalf("expected %s == %v, got %v (%T)", k, want, res[k], res[k])
+		}
+	}
+}

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -1,6 +1,8 @@
 package starlight
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"go.starlark.net/resolve"
@@ -48,5 +50,46 @@ d = outer()
 		if res[k] != want {
 			t.Fatalf("expected %s == %v, got %v (%T)", k, want, res[k], res[k])
 		}
+	}
+}
+
+// TestCacheDialect verifies the cache's compile paths — Run's
+// SourceProgram compile and load()'s ExecFile — use the same explicit
+// dialect (the set built-in must work in both the entry script and a
+// loaded module).
+func TestCacheDialect(t *testing.T) {
+	dir := t.TempDir()
+	module := `
+loaded = set(["x", "y"])
+count = len(loaded)
+`
+	script := `
+load("mod.star", "count")
+s = set([1, 2, 3])
+total = len(s) + count
+`
+	if err := os.WriteFile(filepath.Join(dir, "mod.star"), []byte(module), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.star"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := New(dir)
+	res, err := c.Run("main.star", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["total"] != int64(5) {
+		t.Fatalf("expected total 5, got %v (%T)", res["total"], res["total"])
+	}
+
+	// second run takes the cached-program path
+	res, err = c.Run("main.star", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["total"] != int64(5) {
+		t.Fatalf("expected cached total 5, got %v", res["total"])
 	}
 }

--- a/starlight.go
+++ b/starlight.go
@@ -8,17 +8,17 @@ import (
 	"sync"
 
 	"github.com/1set/starlight/convert"
-	"go.starlark.net/resolve"
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
-func init() {
-	resolve.AllowNestedDef = true // allow def statements within function bodies
-	resolve.AllowLambda = true    // allow lambda expressions
-	resolve.AllowFloat = true     // allow floating point literals, the 'float' built-in, and x / y
-	resolve.AllowSet = true       // allow the 'set' built-in
-	resolve.AllowBitwise = true   // allow bitwise operations
-}
+// dialectOptions is the Starlark dialect starlight compiles with: the
+// standard language plus the 'set' built-in. It is passed explicitly to
+// every compile/exec call instead of mutating the process-global resolve
+// flags, so importing this package has no side effects on other Starlark
+// users in the same process. (Nested def, lambda, float, and bitwise
+// operations are part of the standard dialect already.)
+var dialectOptions = &syntax.FileOptions{Set: true}
 
 // LoadFunc is a function that tells starlark how to find and load other scripts
 // using the load() function.  If you don't use load() in your scripts, you can pass in nil.
@@ -36,9 +36,9 @@ func Eval(src interface{}, globals map[string]interface{}, load LoadFunc) (map[s
 	}
 	filename, ok := src.(string)
 	if ok {
-		dict, err = starlark.ExecFile(thread, filename, nil, dict)
+		dict, err = starlark.ExecFileOptions(dialectOptions, thread, filename, nil, dict)
 	} else {
-		dict, err = starlark.ExecFile(thread, "eval.sky", src, dict)
+		dict, err = starlark.ExecFileOptions(dialectOptions, thread, "eval.sky", src, dict)
 	}
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (c *Cache) Run(filename string, globals map[string]interface{}) (map[string
 	if err != nil {
 		return nil, err
 	}
-	_, p, err := starlark.SourceProgram(filename, b, dict.Has)
+	_, p, err := starlark.SourceProgramOptions(dialectOptions, filename, b, dict.Has)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem

Importing `starlight` (or `convert`) ran `init` functions that rewrote the **process-global** `resolve.*` dialect flags — silently changing the Starlark dialect for every other user of `go.starlark.net` in the same process. Merely importing the conversion package should never have that blast radius.

## Fix

- The dialect is passed explicitly to all four compile/exec points (`Eval`'s two `ExecFile` branches, the cache's `ExecFile`, and the `SourceProgram` compile) via a shared `syntax.FileOptions{Set: true}`.
- Both `init` functions are deleted. Of the five flags they set, four (nested def, lambda, float, bitwise) have long been part of the standard dialect (the globals are deprecated no-ops in the pinned version); only the `set` built-in carries payload, and it is preserved through the options.
- Tests that compiled scripts directly now pass the options explicitly instead of leaning on the side effect.

## ⚠️ Behavior note

Hosts that compile scripts **themselves** with default options and relied on the import side effect for `set` support must now pass `syntax.FileOptions{Set: true}` explicitly. Scripts run through starlight's own entry points are unaffected.

## Tests

`TestNoGlobalDialectMutation` pins that the globals stay untouched after import; `TestDialectCapabilities` pins set/lambda/float/bitwise/nested-def all work through `Eval`. Full suite `-race -count=2` on Go 1.25; Go 1.18/1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)