### PR TITLE
fix: degrade unsupported dynamic values to the opaque wrapper

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -149,7 +149,16 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 			if val.IsNil() {
 				return starlark.None, nil
 			}
-			return toValue(val.Elem(), tagName)
+			if uv, err := toValue(val.Elem(), tagName); err == nil {
+				return uv, nil
+			}
+			// the dynamic value has no Starlark form (e.g. a chan, or a
+			// collection with an unsupported element type) — fall back to
+			// the opaque wrapper instead of erroring: the static pre-check
+			// cannot see through interface{}, and this error would
+			// otherwise surface inside methods that cannot return errors
+			// (Items, Index, iterators) and escape as a panic
+			return &GoInterface{v: val, tag: tagName}, nil
 		}
 		return &GoInterface{v: val, tag: tagName}, nil
 	case reflect.Invalid:

--- a/convert/unwrap_fallback_test.go
+++ b/convert/unwrap_fallback_test.go
@@ -1,0 +1,110 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+)
+
+// Regression tests for dynamic values the unwrapping cannot convert: after
+// empty interfaces started unwrapping to their dynamic value, an element
+// whose dynamic type toValue does not support (e.g. a chan) produced a
+// conversion error inside methods that cannot return errors — items(),
+// values(), GoSlice indexing and iteration all panicked and killed the
+// host. The static collection pre-check cannot help: interface{} element
+// types are checked at runtime, value by value. Such values must fall back
+// to the opaque interface wrapper (the pre-unwrap behavior): inert but
+// printable, and never a panic.
+
+// TestDynamicUnsupportedMapValue drives every materialization path of a
+// map[string]interface{} holding a chan.
+func TestDynamicUnsupportedMapValue(t *testing.T) {
+	ch := make(chan int)
+	codes := []string{
+		`x = m.items()`,
+		`x = m.values()`,
+		`x = m.keys()`,
+		`x = [k for k in m]`,
+		`x = m["bad"]`,
+		`x = str(m)`,
+		`x = len(m)`,
+		`x = m.get("bad")`,
+		`x = m.pop("bad")`,
+	}
+	for _, code := range codes {
+		t.Run(code, func(t *testing.T) {
+			globals := map[string]interface{}{
+				"m": map[string]interface{}{"bad": ch, "good": 1},
+			}
+			if _, err := starlight.Eval([]byte(code), globals, nil); err != nil {
+				t.Fatalf("%s: expected graceful success, got %v", code, err)
+			}
+		})
+	}
+	// the unsupported value comes through as the opaque wrapper
+	globals := map[string]interface{}{
+		"m": map[string]interface{}{"bad": ch},
+	}
+	res, err := starlight.Eval([]byte(`t = type(m["bad"])`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s, ok := res["t"].(string); !ok || !strings.HasPrefix(s, "starlight_") {
+		t.Fatalf("expected opaque wrapper type, got %v", res["t"])
+	}
+}
+
+// TestDynamicUnsupportedSliceElem drives the GoSlice paths (Index and the
+// iterator cannot return errors).
+func TestDynamicUnsupportedSliceElem(t *testing.T) {
+	for _, code := range []string{
+		`x = l[0]`,
+		`x = [e for e in l]`,
+		`x = str(l)`,
+		`x = len(l)`,
+		`x = l.find(1)`,
+	} {
+		t.Run(code, func(t *testing.T) {
+			globals := map[string]interface{}{
+				"l": []interface{}{make(chan int), 1},
+			}
+			if _, err := starlight.Eval([]byte(code), globals, nil); err != nil {
+				t.Fatalf("%s: expected graceful success, got %v", code, err)
+			}
+		})
+	}
+}
+
+// TestDynamicUnsupportedNested covers an interface holding a collection
+// whose static element type is unsupported (rejected by the pre-check when
+// unwrapped) — it must also degrade to the wrapper, not an error or panic.
+func TestDynamicUnsupportedNested(t *testing.T) {
+	globals := map[string]interface{}{
+		"m": map[string]interface{}{"inner": map[string]chan int{"c": make(chan int)}},
+	}
+	res, err := starlight.Eval([]byte(`x = m.items()
+t = type(m["inner"])`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s, ok := res["t"].(string); !ok || !strings.HasPrefix(s, "starlight_") {
+		t.Fatalf("expected opaque wrapper for nested unsupported collection, got %v", res["t"])
+	}
+}
+
+// TestDynamicSupportedStillUnwraps pins that the fallback does not undo the
+// unwrapping for supported dynamic values.
+func TestDynamicSupportedStillUnwraps(t *testing.T) {
+	globals := map[string]interface{}{
+		"m": map[string]interface{}{"a": 1},
+	}
+	res, err := starlight.Eval([]byte(`t = type(m["a"])
+v = m["a"] + 1`), globals, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res["t"] != "int" || res["v"] != int64(2) {
+		t.Fatalf("expected unwrapped int arithmetic, got %v", res)
+	}
+}

--- a/convert/unwrap_fallback_test.go
+++ b/convert/unwrap_fallback_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
 )
 
 // Regression tests for dynamic values the unwrapping cannot convert: after
@@ -90,6 +91,22 @@ t = type(m["inner"])`), globals, nil)
 	}
 	if s, ok := res["t"].(string); !ok || !strings.HasPrefix(s, "starlight_") {
 		t.Fatalf("expected opaque wrapper for nested unsupported collection, got %v", res["t"])
+	}
+}
+
+// TestStaticUnsupportedStillErrors pins the boundary of the degradation:
+// the wrapper fallback applies only to values hidden behind interface{}
+// (unknowable at wrap time). Collections whose static key/element type is
+// unsupported keep failing the conversion up front.
+func TestStaticUnsupportedStillErrors(t *testing.T) {
+	if _, err := convert.MakeDict(map[string]complex128{"b": 3 + 4i}); err == nil {
+		t.Fatal("expected error for statically unsupported value type")
+	}
+	if _, err := convert.MakeDict(map[complex64]string{3i: "b"}); err == nil {
+		t.Fatal("expected error for statically unsupported key type")
+	}
+	if _, err := convert.ToValue(map[string]chan int{}); err == nil {
+		t.Fatal("expected error from the static element pre-check")
 	}
 }
 

--- a/convert/value_test.go
+++ b/convert/value_test.go
@@ -1061,11 +1061,17 @@ assert.Eq(type(t), "starlight_struct<convert_test.mockStr>")
 			wantErrConv: true,
 		},
 		{
-			name: "invalid value",
+			// a value with no Starlark form degrades to the opaque wrapper
+			// (it must not error: the same conversion runs inside dict/list
+			// methods that cannot return errors)
+			name: "unsupported value degrades to wrapper",
 			data: map[interface{}]interface{}{
 				"b": complex(3, 4),
 			},
-			wantErrConv: true,
+			codeSnippet: `
+assert.Eq(type(data), "dict")
+assert.Eq(type(data["b"]).startswith("starlight_"), True)
+`,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
## Problem (regression from #48, found in review)

A dynamic value the unwrapping cannot convert — e.g. a `chan` inside `map[string]interface{}` — produced a conversion error **inside methods that cannot return errors**: `m.items()`, `m.values()`, `GoSlice` indexing and iteration all panicked and killed the host:

```go
globals := map[string]interface{}{"m": map[string]interface{}{"bad": make(chan int)}}
starlight.Eval([]byte(`x = m.items()`), globals, nil) // panic: type chan int is not a supported starlark type
```

Before #48 such values were opaque-but-safe wrappers; the static pre-check from #41 cannot help, since `interface{}` element types are only known value-by-value at runtime.

## Fix

`toValue`'s interface case falls back to the opaque `GoInterface` wrapper when the unwrapped conversion fails — restoring the pre-#48 no-panic degradation while keeping the unwrapping for every supported value (pinned by test).

Consequence: `MakeDict` with an unsupported **value** now degrades to the wrapper instead of erroring (the same conversion runs inside the no-error-channel methods; the wrapper preserves the value for round-trip). Unsupported **keys** still error — the wrapper is unhashable. The one test pinning the old expectation is updated with rationale.

## Tests

New `convert/unwrap_fallback_test.go`: all 9 map materialization paths + 5 slice paths over a chan-valued element, nested unsupported collections, wrapper-type assertion, and a pin that supported values still unwrap. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)