### PR TITLE
fix: clean None policy for typed collection elements

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -842,6 +842,19 @@ func convertSlice(val reflect.Value, argT reflect.Type) (reflect.Value, error) {
 	for i := 0; i < valLen; i++ {
 		elem := val.Index(i)
 
+		// a None element arrives as a nil interface value; apply the same
+		// policy as scalar arguments before any elem.Elem() access (which
+		// panics on a zero Value)
+		if (elem.Kind() == reflect.Interface || elem.Kind() == reflect.Ptr) && elem.IsNil() {
+			switch argElem.Kind() {
+			case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Func:
+				// the zero element is already the nil of the target type
+				continue
+			default:
+				return reflect.Value{}, fmt.Errorf("slice element %d: value of type None cannot be converted to non-nullable type %s", i, argElem)
+			}
+		}
+
 		if elem.Type().AssignableTo(argElem) {
 			newSlice.Index(i).Set(elem)
 		} else if elem.Type().ConvertibleTo(argElem) {
@@ -892,7 +905,14 @@ func convertElemValue(val reflect.Value, targetType reflect.Type) (reflect.Value
 		return checkedConvert(val, targetType)
 	} else if val.Kind() == reflect.Ptr || val.Kind() == reflect.Interface {
 		if val.IsNil() {
-			return reflect.Value{}, fmt.Errorf("nil value cannot be converted to type %v", targetType)
+			// same None policy as the other entry points: nullable target
+			// types accept it as their zero value
+			switch targetType.Kind() {
+			case reflect.Ptr, reflect.Slice, reflect.Map, reflect.Interface, reflect.Func:
+				return reflect.Zero(targetType), nil
+			default:
+				return reflect.Value{}, fmt.Errorf("value of type None cannot be converted to non-nullable type %s", targetType)
+			}
 		}
 		if val.Elem().Type().ConvertibleTo(targetType) {
 			return checkedConvert(val.Elem(), targetType)

--- a/convert/nil_elem_test.go
+++ b/convert/nil_elem_test.go
@@ -1,0 +1,69 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+)
+
+// Regression tests for None elements in typed collection arguments: a None
+// inside a list passed to a Go function taking a typed slice hit
+// reflect.Value.Type on a zero Value inside convertSlice — an internal
+// reflect panic surfaced through the recover as a confusing error instead
+// of a clean checked-conversion error. None must follow the same policy as
+// scalar arguments: allowed for nullable element types, a clear error for
+// non-nullable ones.
+
+// TestNoneSliceElem covers both sides of the policy for slice arguments.
+func TestNoneSliceElem(t *testing.T) {
+	var gotInts []int
+	var gotPtrs []*int
+	globals := map[string]interface{}{
+		"fnInts": func(s []int) { gotInts = s },
+		"fnPtrs": func(s []*int) { gotPtrs = s },
+	}
+
+	_, err := starlight.Eval([]byte(`fnInts([1, None])`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "non-nullable") {
+		t.Fatalf("expected non-nullable element error, got %v", err)
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "reflect") || strings.Contains(err.Error(), "panic") {
+		t.Fatalf("internal reflect panic leaked into the error: %v", err)
+	}
+	if gotInts != nil {
+		t.Fatalf("corrupted slice leaked through: %v", gotInts)
+	}
+
+	if _, err := starlight.Eval([]byte(`fnPtrs([None, None])`), globals, nil); err != nil {
+		t.Fatalf("None must be valid for nullable element types, got %v", err)
+	}
+	if len(gotPtrs) != 2 || gotPtrs[0] != nil || gotPtrs[1] != nil {
+		t.Fatalf("expected [nil nil], got %v", gotPtrs)
+	}
+}
+
+// TestNoneMapElem mirrors the policy for typed map arguments.
+func TestNoneMapElem(t *testing.T) {
+	var gotInts map[string]int
+	var gotPtrs map[string]*int
+	globals := map[string]interface{}{
+		"fnInts": func(m map[string]int) { gotInts = m },
+		"fnPtrs": func(m map[string]*int) { gotPtrs = m },
+	}
+
+	_, err := starlight.Eval([]byte(`fnInts({"a": None})`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "non-nullable") {
+		t.Fatalf("expected non-nullable element error, got %v", err)
+	}
+	if gotInts != nil {
+		t.Fatalf("corrupted map leaked through: %v", gotInts)
+	}
+
+	if _, err := starlight.Eval([]byte(`fnPtrs({"a": None})`), globals, nil); err != nil {
+		t.Fatalf("None must be valid for nullable element types, got %v", err)
+	}
+	if len(gotPtrs) != 1 || gotPtrs["a"] != nil {
+		t.Fatalf("expected {a: nil}, got %v", gotPtrs)
+	}
+}


### PR DESCRIPTION
## Problem (found in review)

`fn([None])` for `func([]int)` hit `reflect.Value.Type` on a zero Value inside `convertSlice` — an internal reflect panic surfaced through the recover as a confusing error (`panic in func fn: reflect: call of reflect.Value.Type on zero Value`) instead of a checked-conversion error. The map path (`fn({"a": None})`) errored, but with different wording and **without accepting None for nullable element types** (`map[string]*int` should take `nil`).

## Fix

Both element paths now follow the exact None policy of scalar arguments (`tryConv`/`convertReflectValue`):

- nullable element types (ptr/slice/map/interface/func) accept None as their zero value — `fnPtrs([None, None])` yields `[]*int{nil, nil}`
- non-nullable ones report `value of type None cannot be converted to non-nullable type T`, with the element index on the slice path

## Tests

`convert/nil_elem_test.go`: both sides of the policy for slices and maps, plus an assertion that no internal reflect/panic wording leaks into errors. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)