### PR TITLE
ci: drop env dump from build logs, document the coverage gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,15 @@ jobs:
           cache: true
       - name: Go Build
         run: |
-          export
-          git status
           go version
           go mod download
       - name: Test
         run: |
           go test -v -race -cover -covermode=atomic -coverprofile=coverage.txt -count 1 ./...
+      # The coverage GATE is the codecov/project and codecov/patch commit
+      # statuses set by the Codecov app after this upload; continue-on-error
+      # here only tolerates upload-channel outages, it does not bypass the
+      # gate.
       - name: Upload Coverage Reports to Codecov
         if: ${{ fromJSON(env.CI_REPORT) }}
         continue-on-error: true


### PR DESCRIPTION
## Changes (found in review)

- The `export` step printed the **entire CI environment** into public logs on every job — needless exposure surface for a public repo. Removed (`git status` debug noise too).
- Documents in-line that the coverage **gate** is the `codecov/project` + `codecov/patch` commit statuses set by the Codecov app (they did gate PRs #44/#48/#49 in practice); the upload step's `continue-on-error` only tolerates reporting-channel outages and does not bypass the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)