### PR TITLE
fix: dict.popitem honors the frozen and iteration guards

### DIFF
--- a/convert/map.go
+++ b/convert/map.go
@@ -341,6 +341,15 @@ func dict_popitem(fnname string, g *GoMap, args starlark.Tuple, _ []starlark.Tup
 	if len(args) > 0 {
 		return nil, fmt.Errorf("%s: wanted 0 args, got %d", fnname, len(args))
 	}
+	// popitem mutates, so it must honor the same guards as the other
+	// mutators; it calls the internal unguarded g.delete below, so the
+	// checks have to be here (frozen first, matching Delete/pop)
+	if g.frozen {
+		return nil, fmt.Errorf("cannot delete from frozen map")
+	}
+	if atomic.LoadInt32(&g.numIt) > 0 {
+		return nil, fmt.Errorf("cannot delete from map during iteration")
+	}
 	keys := sortedMapKeys(g.v)
 	if len(keys) == 0 {
 		return nil, fmt.Errorf("popitem: empty dict")

--- a/convert/popitem_guard_test.go
+++ b/convert/popitem_guard_test.go
@@ -1,0 +1,109 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// Regression tests for dict.popitem's mutation guards. Every other GoMap
+// mutation entry point (SetKey, Clear, Delete/pop) rejects writes on a
+// frozen map and during iteration; popitem called the internal unguarded
+// delete, so it silently mutated frozen maps and mutated maps mid-iteration
+// where its sibling pop() correctly errors.
+
+// TestPopitemFrozen verifies popitem on a frozen GoMap errors instead of
+// mutating, matching pop().
+func TestPopitemFrozen(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2}
+	g := convert.NewGoMap(m)
+	g.Freeze()
+	globals := map[string]interface{}{"m": g}
+
+	_, err := starlight.Eval([]byte(`x = m.popitem()`), globals, nil)
+	if err == nil || !strings.Contains(err.Error(), "frozen") {
+		t.Fatalf("expected frozen error, got %v", err)
+	}
+	if len(m) != 2 {
+		t.Fatalf("expected frozen map unchanged, got %v", m)
+	}
+}
+
+// TestPopitemDuringIteration verifies popitem during an active iteration of
+// the same map errors, matching pop(). Driven at the API level because a
+// Starlark for-loop must live in a function.
+func TestPopitemDuringIteration(t *testing.T) {
+	g := convert.NewGoMap(map[string]int{"a": 1, "b": 2, "c": 3})
+	it := g.Iterate()
+	defer it.Done()
+	var k starlark.Value
+	it.Next(&k) // open the iteration (numIt > 0)
+
+	piFn, err := g.Attr("popitem")
+	if err != nil || piFn == nil {
+		t.Fatal("no popitem attr")
+	}
+	_, piErr := starlark.Call(&starlark.Thread{}, piFn.(*starlark.Builtin), nil, nil)
+	if piErr == nil || !strings.Contains(piErr.Error(), "during iteration") {
+		t.Fatalf("expected during-iteration error, got %v", piErr)
+	}
+
+	// pop() agrees
+	popFn, _ := g.Attr("pop")
+	_, popErr := starlark.Call(&starlark.Thread{}, popFn.(*starlark.Builtin), starlark.Tuple{starlark.String("a")}, nil)
+	if popErr == nil || !strings.Contains(popErr.Error(), "during iteration") {
+		t.Fatalf("pop should also error during iteration, got %v", popErr)
+	}
+}
+
+// TestPopitemGuardsMatchPop directly compares popitem and pop guard
+// behavior at the API level to ensure they agree.
+func TestPopitemGuardsMatchPop(t *testing.T) {
+	makeFrozen := func() *convert.GoMap {
+		g := convert.NewGoMap(map[string]int{"a": 1})
+		g.Freeze()
+		return g
+	}
+	// pop on frozen
+	gp := makeFrozen()
+	popFn, err := gp.Attr("pop")
+	if err != nil || popFn == nil {
+		t.Fatal("no pop attr")
+	}
+	_, popErr := starlark.Call(&starlark.Thread{}, popFn.(*starlark.Builtin), starlark.Tuple{starlark.String("a")}, nil)
+	// popitem on frozen
+	gpi := makeFrozen()
+	piFn, err := gpi.Attr("popitem")
+	if err != nil || piFn == nil {
+		t.Fatal("no popitem attr")
+	}
+	_, piErr := starlark.Call(&starlark.Thread{}, piFn.(*starlark.Builtin), nil, nil)
+
+	if popErr == nil || piErr == nil {
+		t.Fatalf("both must error on frozen: pop=%v popitem=%v", popErr, piErr)
+	}
+	if !strings.Contains(piErr.Error(), "frozen") {
+		t.Fatalf("popitem frozen error should mention frozen, got %v", piErr)
+	}
+}
+
+// TestPopitemStillWorks pins the happy path: popitem on a mutable,
+// non-iterating map still pops the deterministic smallest key.
+func TestPopitemStillWorks(t *testing.T) {
+	m := map[string]int{"c": 3, "a": 1, "b": 2}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"m":      m,
+	}
+	code := []byte(`
+assert.Eq(m.popitem(), ("a", 1))
+assert.Eq(m.popitem(), ("b", 2))
+assert.Eq(len(m), 1)
+`)
+	if _, err := starlight.Eval(code, globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Problem (found in review)

`popitem` was the **only** GoMap mutation site that escaped the guards: it calls the internal unguarded `g.delete`, while every sibling (`SetKey`, `Clear`, `Delete`/`pop`) checks `g.frozen` and the atomic `numIt` iteration counter first. So:

- `popitem()` on a **frozen** map silently mutated it (`pop()` errors `cannot delete from frozen map`);
- `popitem()` **during iteration** of the same map mutated it (`pop()` errors `cannot delete from map during iteration`).

The freeze/concurrency guards from #43 added these checks everywhere but popitem, and no test pinned them — a future refactor would ship the regression silently.

## Fix

Add the two checks (frozen first, matching `Delete`) at the top of `dict_popitem`, before it reaches the internal delete.

## Tests

`convert/popitem_guard_test.go`: popitem on frozen map errors and leaves it unchanged; popitem during an active iteration errors; both guards match `pop()`'s behavior; happy-path popitem still pops the deterministic smallest key. Full suite `-race -count=2` on Go 1.25; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)