### PR TITLE
fix: don't double-quote the kwargs error; correct a wrong dead-code comment

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -689,7 +689,7 @@ func makeStarFn(name string, gofn reflect.Value, tagName string) *starlark.Built
 		}()
 
 		if len(kwargs) > 0 {
-			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %q (wrapped Go functions accept positional arguments only)", name, kwargs[0][0])
+			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %s (wrapped Go functions accept positional arguments only)", name, kwargs[0][0].String())
 		}
 		if len(args) != gofn.Type().NumIn() {
 			return starlark.None, fmt.Errorf("expected %d args but got %d", gofn.Type().NumIn(), len(args))
@@ -726,7 +726,7 @@ func makeVariadicStarFn(name string, gofn reflect.Value, tagName string) *starla
 		}()
 
 		if len(kwargs) > 0 {
-			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %q (wrapped Go functions accept positional arguments only)", name, kwargs[0][0])
+			return starlark.None, fmt.Errorf("%s: unexpected keyword argument %s (wrapped Go functions accept positional arguments only)", name, kwargs[0][0].String())
 		}
 		minArgs := gofn.Type().NumIn() - 1
 		if len(args) < minArgs {
@@ -927,7 +927,10 @@ func convertElemValue(val reflect.Value, targetType reflect.Type) (reflect.Value
 			if unwrapped.Type().ConvertibleTo(targetType) {
 				return checkedConvert(unwrapped, targetType)
 			} else if sv, ok := unwrapped.Interface().(starlark.Value); ok {
-				// TODO: this path is not reachable in the current test, maybe we can remove it?
+				// reached when a host passes a custom starlark.Value inside a
+				// collection argument (e.g. map[string]interface{}{"k":
+				// myStarlarkValue}) to a typed Go parameter: FromValue leaves
+				// such values as-is, so we unwrap and re-narrow here
 				goVal := FromValue(sv)
 				goVal = convertNumericTypes(goVal, targetType)
 				if reflect.TypeOf(goVal) != targetType {

--- a/convert/conv_cleanup_test.go
+++ b/convert/conv_cleanup_test.go
@@ -1,0 +1,61 @@
+package convert_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// TestKwargsErrorNotDoubleQuoted verifies the unexpected-keyword error names
+// the argument once, not double-quoted. kwargs[0][0] is a starlark.String
+// whose String() already quotes, so the old %q produced the literal
+// "\"name\"".
+func TestKwargsErrorNotDoubleQuoted(t *testing.T) {
+	globals := map[string]interface{}{
+		"quote":  func(s string) string { return s },
+		"concat": func(ss ...string) string { return strings.Join(ss, "") },
+	}
+	for _, code := range []string{`quote("a", bogus=1)`, `concat("a", bogus=1)`} {
+		_, err := starlight.Eval([]byte(code), globals, nil)
+		if err == nil {
+			t.Fatalf("%s: expected error", code)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, `argument "bogus"`) {
+			t.Fatalf("%s: expected single-quoted arg name, got %q", code, msg)
+		}
+		if strings.Contains(msg, `\"bogus\"`) || strings.Contains(msg, `"\"bogus\""`) {
+			t.Fatalf("%s: argument name is double-quoted: %q", code, msg)
+		}
+	}
+}
+
+// reNarrowValue is a custom starlark.Value FromValue leaves as-is, used to
+// reach the collection-element starlark.Value re-narrowing branch in
+// convertElemValue (the one whose comment used to claim it was unreachable).
+type reNarrowValue struct{ n int64 }
+
+func (reNarrowValue) String() string        { return "reNarrowValue" }
+func (reNarrowValue) Type() string          { return "reNarrowValue" }
+func (reNarrowValue) Freeze()               {}
+func (reNarrowValue) Truth() starlark.Bool  { return true }
+func (reNarrowValue) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable") }
+
+// TestConvertElemStarlarkValueBranchReachable proves the branch is live: a
+// custom starlark.Value inside a collection passed to a typed Go parameter
+// reaches the re-narrowing path and errors cleanly (it is not numeric).
+func TestConvertElemStarlarkValueBranchReachable(t *testing.T) {
+	fn := convert.MakeStarFn("fn", func(m map[string]int) int { return len(m) })
+	globals := starlark.StringDict{"fn": fn, "c": reNarrowValue{n: 5}}
+	_, err := starlark.ExecFile(&starlark.Thread{}, "t.star", `x = fn({"a": c})`, globals)
+	if err == nil {
+		t.Fatal("expected a conversion error for a non-numeric custom value")
+	}
+	if !strings.Contains(err.Error(), "reNarrowValue") {
+		t.Fatalf("expected error to mention the custom type, got %v", err)
+	}
+}


### PR DESCRIPTION
## Two small conv.go fixes (found in review)

**1. Kwargs error double-quoted the argument name.** The unexpected-keyword error (from #45) applied `%q` to `kwargs[0][0]`, a `starlark.String` whose `String()` already returns a quoted form — so the user saw the literal `"\"bogus\""`. Now uses the Go string, quoting once: `unexpected keyword argument "bogus"`.

**2. A 'not reachable' comment was wrong.** `convertElemValue` carried `// TODO: this path is not reachable in the current test, maybe we can remove it?`. It **is** reachable from host code — passing a custom `starlark.Value` inside a collection argument (`map[string]interface{}{"k": myValue}`) to a typed Go parameter routes through it (`FromValue` leaves such values as-is). A probe confirmed it (the `expected type int got …` error originates on that line). Replaced the comment with an accurate description **and added a test that exercises the branch**, so a future cleanup will not mistake it for dead code and delete a live path.

## Tests

`convert/conv_cleanup_test.go`: the kwargs error names the argument exactly once (not double-quoted), for both fixed and variadic functions; and a custom `starlark.Value` in a collection arg reaches the re-narrowing branch and errors cleanly. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)