### PR TITLE
docs: correct stale claims found in review (no behavior change)

### DIFF
--- a/README-old.md
+++ b/README-old.md
@@ -81,8 +81,11 @@ script as-is (this is useful if you need custom behavior).
 
 You can pass go functions that the script can call by passing your function in
 with the rest of the globals. Positional args are passed to your function and
-converted to their appropriate go type if possible. Kwargs passed from starlark
-scripts are currently ignored.
+converted to their appropriate go type if possible.
+
+(Note: this fork no longer silently ignores keyword arguments — calling a
+wrapped Go function with a kwarg now raises an "unexpected keyword argument"
+error, since wrapped functions accept positional arguments only.)
 
 ## Caching
 

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -144,6 +144,11 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 		// since the opaque wrapper supports no comparison or arithmetic
 		// (m["a"] == 1 was False, m["a"] + 1 failed). Interfaces with
 		// methods keep the wrapper, which exposes those methods.
+		//
+		// Caveat: unwrapping routes the value through Starlark, so a sized
+		// numeric (int16, float32, ...) stored in an interface collection
+		// round-trips through the FromValue ladder and comes back widened
+		// (int64 / float64), not its exact original Go type.
 		if val.Type().NumMethod() == 0 {
 			if val.IsNil() {
 				return starlark.None, nil
@@ -777,7 +782,13 @@ func makeOut(out []reflect.Value, tagName string) (starlark.Value, error) {
 	var err error
 	// the error-return convention matches any type implementing error, not
 	// just the error interface itself: a concrete error type in the last
-	// position used to leak through as a regular value instead of raising
+	// position used to leak through as a regular value instead of raising.
+	//
+	// Edge case: a value (non-pointer) type whose Error() has a value
+	// receiver can never be nil, so the isNil guard below cannot treat its
+	// zero value as "no error" — such a return always raises. Idiomatic Go
+	// errors are pointer/interface types (nilable), so this is rare; use a
+	// nilable error type if a zero-value "no error" sentinel is needed.
 	if last.Type() == errType || last.Type().Implements(errType) {
 		isNil := false
 		switch last.Kind() {

--- a/convert/map.go
+++ b/convert/map.go
@@ -337,6 +337,11 @@ func dict_pop(fnname string, g *GoMap, args starlark.Tuple, _ []starlark.Tuple) 
 }
 
 // https://github.com/google/starlark-go/blob/master/doc/spec.md#dict·popitem
+//
+// Note: the spec's popitem removes the last-inserted item (LIFO), but a Go
+// map has no insertion order to honor. To stay deterministic this pops the
+// smallest key under the same ordering Keys()/Items() use (type rank, then
+// value), not the last-inserted one.
 func dict_popitem(fnname string, g *GoMap, args starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
 	if len(args) > 0 {
 		return nil, fmt.Errorf("%s: wanted 0 args, got %d", fnname, len(args))

--- a/convert/safestring_test.go
+++ b/convert/safestring_test.go
@@ -57,8 +57,9 @@ func TestGoStructSelfRefString(t *testing.T) {
 }
 
 // TestScriptStrSelfRef verifies str() in a script cannot crash the host on
-// self-referential values, including the GoInterface wrapping that map
-// element access produces.
+// self-referential values. m["self"] unwraps to the GoMap itself (empty
+// interfaces are unwrapped to their dynamic value), so both str(m) and
+// str(m["self"]) format the cyclic map safely.
 func TestScriptStrSelfRef(t *testing.T) {
 	m := map[string]interface{}{}
 	m["self"] = m


### PR DESCRIPTION
## Five documentation/comment fixes (found in review)

No behavior change — only comments and `README-old.md`.

- **`dict_popitem`** links the Starlark spec (which pops the last-inserted item, LIFO), but a Go map has no insertion order to honor. Documents that it pops the deterministic *smallest* key under the `Keys()`/`Items()` ordering instead.
- **Empty-interface unwrap (#48)** now documents that a sized numeric (`int16`/`float32`/...) stored in an interface collection round-trips *widened* to `int64`/`float64` through the `FromValue` ladder, not its exact original Go type.
- **`README-old.md`** said keyword args are "currently ignored"; this fork now rejects them (#45). Noted.
- **`TestScriptStrSelfRef`** comment claimed `str(m["self"])` exercises a `GoInterface` wrapper, but after #48 `m["self"]` unwraps to the `GoMap`. Comment corrected.
- **`makeOut`** documents the value-typed-error edge: a non-pointer error type with a value receiver can never be nil, so its zero value always raises — use a nilable error type for a "no error" sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)