### PR TITLE
test: pin recursive-type and cross-collection cycle handling

### DIFF
--- a/convert/freeze_race_test.go
+++ b/convert/freeze_race_test.go
@@ -156,3 +156,88 @@ func TestFromListCycle(t *testing.T) {
 		t.Fatalf("expected cyclic reference to convert to a nil slice, got %#v", got[1])
 	}
 }
+
+// TestFromDictCycle verifies a self-referential dict converts its cyclic
+// reference to nil instead of recursing forever. The package-level
+// recursion detector this used to rely on was replaced (#43) by a visited
+// set threaded through fromValue/fromDict; this and TestFromListCycle /
+// TestCrossCollectionCycle are the black-box coverage for that protection
+// (the old white-box recursionDetector unit test was removed with it).
+func TestFromDictCycle(t *testing.T) {
+	d := starlark.NewDict(1)
+	if err := d.SetKey(starlark.String("self"), d); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetKey(starlark.String("v"), starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromDict(d)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %#v", got)
+	}
+	if got["v"] != int64(1) {
+		t.Fatalf("expected v=1, got %#v", got["v"])
+	}
+	if m, ok := got["self"].(map[interface{}]interface{}); !ok || m != nil {
+		t.Fatalf("expected self-reference to convert to a nil map, got %#v", got["self"])
+	}
+}
+
+// TestCrossCollectionCycle verifies a cycle spanning multiple collection
+// kinds (list -> dict -> back to list) is broken at the revisit, not
+// followed into a stack overflow.
+func TestCrossCollectionCycle(t *testing.T) {
+	l := starlark.NewList(nil)
+	d := starlark.NewDict(1)
+	if err := d.SetKey(starlark.String("back"), l); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Append(starlark.MakeInt(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := l.Append(d); err != nil {
+		t.Fatal(err)
+	}
+	got := convert.FromList(l)
+	if len(got) != 2 || got[0] != int64(1) {
+		t.Fatalf("expected [1, {back:nil}], got %#v", got)
+	}
+	inner, ok := got[1].(map[interface{}]interface{})
+	if !ok {
+		t.Fatalf("expected inner dict, got %#v", got[1])
+	}
+	// the back-reference to the outer list is broken (nil), no stack overflow
+	if s, ok := inner["back"].([]interface{}); !ok || s != nil {
+		t.Fatalf("expected back-reference to convert to nil slice, got %#v", inner["back"])
+	}
+}
+
+// TestDeepNestingNoStackOverflow verifies very deep (but acyclic) nesting
+// converts without overflowing the stack — the visited set keys on the
+// pointers actually on the current path, so depth alone is fine.
+func TestDeepNestingNoStackOverflow(t *testing.T) {
+	const depth = 2000
+	cur := starlark.NewList(nil)
+	root := cur
+	for i := 0; i < depth; i++ {
+		next := starlark.NewList(nil)
+		if err := cur.Append(next); err != nil {
+			t.Fatal(err)
+		}
+		cur = next
+	}
+	got := convert.FromList(root)
+	// walk down to confirm it materialized fully
+	n := 0
+	for len(got) == 1 {
+		nxt, ok := got[0].([]interface{})
+		if !ok {
+			break
+		}
+		got = nxt
+		n++
+	}
+	if n != depth {
+		t.Fatalf("expected to walk %d levels, got %d", depth, n)
+	}
+}

--- a/convert/panics_test.go
+++ b/convert/panics_test.go
@@ -134,3 +134,32 @@ func TestUnsupportedElemType(t *testing.T) {
 		t.Fatal("expected conversion error for chan-valued map global")
 	}
 }
+
+// recursiveMapType is a genuinely recursive Go TYPE definition (its element
+// type is itself), unlike recMap above whose element type is interface{}.
+// It exercises the visited-set guard in checkCollectionElemTypes: without
+// it, the type pre-check would recurse forever on the type graph.
+type recursiveMapType map[string]recursiveMapType
+
+// recursiveSliceType is the slice analogue (element type is itself).
+type recursiveSliceType []recursiveSliceType
+
+// TestRecursiveTypeDefinition verifies the type pre-check terminates on
+// recursive type definitions (the documented purpose of the visited set).
+// A timeout/hang here is the failure mode being guarded against.
+func TestRecursiveTypeDefinition(t *testing.T) {
+	rm := recursiveMapType{"a": recursiveMapType{}}
+	if _, err := convert.ToValue(rm); err != nil {
+		t.Fatalf("recursive map type should convert, got %v", err)
+	}
+	rs := recursiveSliceType{recursiveSliceType{}}
+	if _, err := convert.ToValue(rs); err != nil {
+		t.Fatalf("recursive slice type should convert, got %v", err)
+	}
+	// a recursive type that bottoms out in an unsupported element still
+	// terminates and reports the error rather than hanging
+	type badRec map[string]chan int
+	if _, err := convert.ToValue(badRec{}); err == nil {
+		t.Fatal("expected error for recursive-shaped type with chan element")
+	}
+}


### PR DESCRIPTION
## Why (found in review)

A reviewer asked: *"the package-level recursion detector was removed (#43) — where is the test for that protection?"* #43 replaced the global `recursionDetector` with a `visited` set threaded through `fromValue`/`fromList`/`fromDict`, and removed the old white-box `recursionDetector` unit test. The black-box replacements were `TestFromListCycle` and `TestConcurrentFromValue`; this fills the remaining gaps.

## Tests added (test-only, no behavior change)

- **`TestRecursiveTypeDefinition`** — a genuinely recursive Go *type* (`type R map[string]R` and the slice analogue) terminates the `checkCollectionElemTypes` pre-check via its visited-set guard. The pre-existing `recMap` test only used a recursive *value* (element type `interface{}`), which never exercised that guard — so the guard was asserted only by comment until now.
- **`TestFromDictCycle`** — a self-referential dict converts its cyclic reference to a nil map (the `FromDict` counterpart of the existing list-cycle test).
- **`TestCrossCollectionCycle`** — a cycle spanning `list → dict → list` is broken at the revisit, not followed into a stack overflow.
- **`TestDeepNestingNoStackOverflow`** — 2000-deep acyclic nesting converts fully (depth alone is fine; the visited set keys on pointers on the current path).

Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)