### PR TITLE
fix: reject identity-comparable values as Go map keys

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -482,10 +482,43 @@ func hashableGoValue(v starlark.Value) (interface{}, error) {
 	if bi, ok := g.(*big.Int); ok {
 		return bigIntKey{s: bi.String()}, nil
 	}
-	if !reflect.TypeOf(g).Comparable() {
+	gt := reflect.TypeOf(g)
+	if !gt.Comparable() {
 		return nil, fmt.Errorf("value of type %s converts to Go type %T which is not hashable", v.Type(), g)
 	}
+	if !comparableByValue(gt) {
+		// Comparable() is true for pointers/chans, but they compare by
+		// identity, not value — so equal Starlark values (e.g. two equal
+		// structs, or a custom pointer-backed value) would become distinct,
+		// unretrievable Go map keys. Reject rather than silently misbehave,
+		// matching the unhashable-key contract. (*big.Int is intercepted
+		// above; FromDict falls back to the key's printed form.)
+		return nil, fmt.Errorf("value of type %s converts to Go type %T which compares by identity, not value, so it is not usable as a stable map key", v.Type(), g)
+	}
 	return g, nil
+}
+
+// comparableByValue reports whether two equal values of type t compare equal
+// as Go map keys by VALUE. reflect.Type.Comparable() is necessary but not
+// sufficient: pointers, channels, and unsafe.Pointers are comparable yet
+// compare by identity, and a struct or array is value-comparable only if
+// every element is. Interface fields are treated as identity (their dynamic
+// value is unknown).
+func comparableByValue(t reflect.Type) bool {
+	switch t.Kind() {
+	case reflect.Ptr, reflect.Chan, reflect.UnsafePointer, reflect.Interface:
+		return false
+	case reflect.Array:
+		return comparableByValue(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if !comparableByValue(t.Field(i).Type) {
+				return false
+			}
+		}
+		return true
+	}
+	return true
 }
 
 // tryKeyConv converts a Starlark value used as a map key into a

--- a/convert/identity_key_test.go
+++ b/convert/identity_key_test.go
@@ -1,0 +1,67 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// Regression tests for identity-comparable map keys: a Starlark value whose
+// Go form is comparable by POINTER IDENTITY rather than by value
+// (*starlarkstruct.Struct, *starlarkstruct.Module, custom pointer-backed
+// values) used to pass the reflect.Comparable() gate in hashableGoValue and
+// silently key a wrapped Go map by identity — so equal values became
+// distinct, unretrievable keys (the same class as the *big.Int bug). They
+// must now error cleanly, like other unhashable-by-value keys.
+
+func TestStructKeyErrorsNotIdentityKeyed(t *testing.T) {
+	g := convert.NewGoMap(map[interface{}]interface{}{})
+	st := starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+		"a": starlark.MakeInt(1),
+	})
+	err := g.SetKey(st, starlark.String("x"))
+	if err == nil || !strings.Contains(err.Error(), "hashable") && !strings.Contains(err.Error(), "identity") {
+		t.Fatalf("expected a clean key error for a struct value, got %v", err)
+	}
+}
+
+// pointerCustom is a custom starlark.Value backed by a Go pointer (so
+// FromValue returns it as-is and it compares by identity).
+type pointerCustom struct{ n int }
+
+func (p *pointerCustom) String() string        { return "pointerCustom" }
+func (p *pointerCustom) Type() string          { return "pointerCustom" }
+func (p *pointerCustom) Freeze()               {}
+func (p *pointerCustom) Truth() starlark.Bool  { return true }
+func (p *pointerCustom) Hash() (uint32, error) { return uint32(p.n), nil }
+
+func TestPointerBackedCustomKeyErrors(t *testing.T) {
+	g := convert.NewGoMap(map[interface{}]interface{}{})
+	err := g.SetKey(&pointerCustom{n: 1}, starlark.String("x"))
+	if err == nil {
+		t.Fatal("expected a clean key error for a pointer-backed custom value, got nil")
+	}
+}
+
+// big.Int keys must STILL work (canonicalized), and normal keys unaffected —
+// regression guards for the generalization.
+func TestNormalKeysStillWorkAfterIdentityGuard(t *testing.T) {
+	g := convert.NewGoMap(map[interface{}]interface{}{})
+	for _, k := range []starlark.Value{
+		starlark.String("s"),
+		starlark.MakeInt(7),
+		starlark.MakeInt64(1).Lsh(70), // big.Int -> bigIntKey
+		starlark.Tuple{starlark.MakeInt(1), starlark.String("a")},
+		starlark.Bytes("b"),
+	} {
+		if err := g.SetKey(k, starlark.String("v")); err != nil {
+			t.Fatalf("key %v should be usable, got %v", k, err)
+		}
+		if v, _, err := g.Get(k); err != nil || v != starlark.String("v") {
+			t.Fatalf("key %v round-trip failed: v=%v err=%v", k, v, err)
+		}
+	}
+}

--- a/convert/internal_test.go
+++ b/convert/internal_test.go
@@ -110,3 +110,44 @@ func TestToValuePanicSentinel(t *testing.T) {
 		t.Fatalf("expected stack to identify the conversion frame, got:\n%s", pe.Stack)
 	}
 }
+
+// TestComparableByValue covers every branch of the map-key value-comparability
+// check: scalars and value-only composites are value-comparable; pointers,
+// channels, unsafe.Pointers, interfaces, and any array/struct transitively
+// containing them are not.
+func TestComparableByValue(t *testing.T) {
+	type valStruct struct {
+		A int
+		B string
+	}
+	type ptrStruct struct {
+		A int
+		P *int
+	}
+	type ifaceStruct struct {
+		V interface{}
+	}
+	cases := []struct {
+		t    reflect.Type
+		want bool
+	}{
+		{reflect.TypeOf(0), true},               // scalar -> default true
+		{reflect.TypeOf(""), true},              // scalar
+		{reflect.TypeOf(1.5), true},             // scalar
+		{reflect.TypeOf((*int)(nil)), false},    // ptr
+		{reflect.TypeOf(make(chan int)), false}, // chan
+		{reflect.TypeOf([2]int{}), true},        // array of scalar
+		{reflect.TypeOf([2]*int{}), false},      // array of ptr
+		{reflect.TypeOf(valStruct{}), true},     // struct, all value
+		{reflect.TypeOf(ptrStruct{}), false},    // struct with ptr field
+		{reflect.TypeOf(ifaceStruct{}), false},  // struct with interface field
+		{reflect.TypeOf([1][2]int{}), true},     // nested array of scalar
+		{reflect.TypeOf([1]valStruct{}), true},  // array of value struct
+		{reflect.TypeOf([1]ptrStruct{}), false}, // array of ptr-bearing struct
+	}
+	for _, c := range cases {
+		if got := comparableByValue(c.t); got != c.want {
+			t.Errorf("comparableByValue(%s) = %v, want %v", c.t, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (found by the type-coverage audit — same class as #59)

`hashableGoValue` gated only on `reflect.Type.Comparable()`. That is **necessary but not sufficient**: pointers, channels and `unsafe.Pointer`s are comparable, but they compare **by identity, not by value**. So a Starlark value whose Go form is such a pointer — `*starlarkstruct.Struct`, `*starlarkstruct.Module`, or a custom pointer-backed `starlark.Value` — silently keyed a wrapped `map[interface{}]V` **by identity**: equal values became distinct, unretrievable keys. Exactly the bug `*big.Int` had in #59, just a wider set of types.

## Fix

New `comparableByValue` helper: pointers/chans/unsafe.Pointers (and any struct or array containing them, or an interface field) are not value-comparable. `hashableGoValue` rejects such keys with a clean error, matching the existing unhashable-key contract. `*big.Int` stays canonicalized to `bigIntKey`; `FromDict` still falls back to the key's printed form, so its path is unaffected.

This turns silent data corruption into a clear error — strictly better than the half-working identity-keying it replaces.

## Tests

`convert/identity_key_test.go`: a `*starlarkstruct.Struct` key and a pointer-backed custom value now error; string/int/big-int/tuple/bytes keys still round-trip (regression guard). Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)