### PR TITLE
fix: pointer-to-func no longer panics the host

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -91,14 +91,16 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	if kind == reflect.Ptr {
 		if val.Elem().IsValid() {
 			kind = val.Elem().Kind()
-			// for pointers to basic types, dereference them
+			// for pointers to basic/collection types and funcs, dereference
+			// them (a non-nil *func becomes a callable; without this the Func
+			// case would call makeStarFn on the pointer and panic)
 			switch kind {
 			case reflect.Bool,
 				reflect.String,
 				reflect.Float32, reflect.Float64,
 				reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 				reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-				reflect.Slice, reflect.Array, reflect.Map:
+				reflect.Slice, reflect.Array, reflect.Map, reflect.Func:
 				val = val.Elem()
 			}
 		} else {
@@ -213,7 +215,15 @@ func checkCollectionElemTypes(t reflect.Type, visited map[reflect.Type]bool) err
 			return err
 		}
 		return checkCollectionElemTypes(t.Elem(), visited)
-	case reflect.Slice, reflect.Array, reflect.Ptr:
+	case reflect.Ptr:
+		// a *func element is unsupported: a nil one errors in toValue, and
+		// GoSlice.Index / iterators cannot return that error (they would
+		// panic). A direct func element is fine (it stays callable).
+		if t.Elem().Kind() == reflect.Func {
+			return fmt.Errorf("type %s is not a supported starlark type", t)
+		}
+		return checkCollectionElemTypes(t.Elem(), visited)
+	case reflect.Slice, reflect.Array:
 		return checkCollectionElemTypes(t.Elem(), visited)
 	}
 	return nil

--- a/convert/func_pointer_test.go
+++ b/convert/func_pointer_test.go
@@ -1,0 +1,51 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+)
+
+// Regression tests for pointer-to-func: toValue's pre-switch deref left
+// `*func` as a pointer while setting kind=Func, so the Func case called
+// makeStarFn on a pointer and panicked. A non-nil *func should deref to a
+// callable; a nil *func and *func-element collections should error cleanly,
+// never panic.
+
+func TestPointerToFuncCallable(t *testing.T) {
+	fn := func(x int) int { return x * 2 }
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"f":      &fn, // *func
+	}
+	if _, err := starlight.Eval([]byte(`assert.Eq(f(21), 42)`), globals, nil); err != nil {
+		t.Fatalf("*func should be callable, got %v", err)
+	}
+}
+
+func TestNilPointerToFuncErrors(t *testing.T) {
+	var fn *func(int) int
+	_, err := convert.ToValue(fn)
+	if err == nil {
+		t.Fatal("nil *func should error, not panic")
+	}
+}
+
+func TestFuncPointerSliceRejected(t *testing.T) {
+	fn := func() {}
+	// a slice of *func: rejected at conversion time, not a panic on access
+	if _, err := convert.ToValue([]*func(){&fn}); err == nil {
+		t.Fatal("[]*func should be rejected at conversion time")
+	}
+	// plain []func still works (each element is callable)
+	v, err := convert.ToValue([]func(){fn})
+	if err != nil {
+		t.Fatalf("[]func should convert, got %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected a wrapped slice")
+	}
+	_ = strings.TrimSpace
+}


### PR DESCRIPTION
## Problem (found by the type-coverage audit, gaps H1/H7)

`toValue`'s pre-switch pointer dereference covered basic and collection pointee kinds but **not Func**, so a `*func` reached the `reflect.Func` case still as a pointer, and `makeStarFn` panicked: `reflect: IsVariadic of non-func type *func(int) int`. Reachable when a host registers a `*func` value (directly or as a collection element).

## Fix

- Deref `*func` like the other pointer kinds in the pre-switch — a non-nil `*func` becomes a callable; a nil `*func` still errors cleanly (unchanged).
- Reject **pointer-to-func element types** in `checkCollectionElemTypes`: a nil `*func` element errors in `toValue`, and `GoSlice.Index` / iterators cannot return that error (they would panic), so such collections are rejected at wrap time. Plain `[]func` is unaffected (its elements stay callable).

## Tests

`convert/func_pointer_test.go`: a non-nil `*func` is callable from a script; a nil `*func` errors; `[]*func` is rejected while `[]func` still converts. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)