### PR TITLE
fix: typed-collection element conversion no longer panics or silently wraps

### DIFF
--- a/convert/collection_elem_test.go
+++ b/convert/collection_elem_test.go
@@ -1,0 +1,69 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+	"go.starlark.net/starlark"
+)
+
+// Regression tests for typed-collection argument conversion.
+
+// TestConvertSliceConcreteElemNoPanic: a wrapped Go slice with concrete
+// element kind (e.g. []int8), passed to a Go func whose parameter element
+// type it is neither assignable nor convertible to, used to reach
+// convertSlice's elem.Elem() on a non-pointer/non-interface value and panic
+// internally (recovered into a confusing "reflect:" error). It must produce
+// a clean type-mismatch error instead.
+func TestConvertSliceConcreteElemNoPanic(t *testing.T) {
+	globals := map[string]interface{}{
+		"fn": func(s []chan int) int { return len(s) },
+		"s":  []int8{1, 2, 3},
+	}
+	_, err := starlight.Eval([]byte(`x = fn(s)`), globals, nil)
+	if err == nil {
+		t.Fatal("expected a type-mismatch error")
+	}
+	if strings.Contains(err.Error(), "reflect:") || strings.Contains(err.Error(), "Elem on") {
+		t.Fatalf("internal reflect panic leaked into the error: %v", err)
+	}
+}
+
+// TestConvertElemStarlarkValueChecked: a Go map holding a raw starlark.Value
+// element, passed to a func with a narrow integer element type, went through
+// the unchecked convertNumericTypes and silently wrapped an out-of-range
+// value. It must now error like every other checked conversion.
+func TestConvertElemStarlarkValueChecked(t *testing.T) {
+	var got int8
+	globals := map[string]interface{}{
+		"fn": func(m map[string]int8) { got = m["k"] },
+		"m":  map[string]interface{}{"k": starlark.MakeInt(1000)}, // 1000 overflows int8
+	}
+	_, err := starlight.Eval([]byte(`fn(m)`), globals, nil)
+	if err == nil {
+		t.Fatalf("expected out-of-range error; instead got silent value %d", got)
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("expected out-of-range error, got %v", err)
+	}
+	// a None value into a non-convertible element type (bool) reaches the
+	// starlark.Value branch's nil-guard cleanly (not a panic)
+	gb := map[string]interface{}{
+		"fn": func(m map[string]bool) {},
+		"m":  map[string]interface{}{"k": starlark.None},
+	}
+	if _, err := starlight.Eval([]byte(`fn(m)`), gb, nil); err == nil {
+		t.Fatal("expected error for None into a bool element")
+	}
+
+	// an in-range value still works
+	got = 0
+	globals["m"] = map[string]interface{}{"k": starlark.MakeInt(100)}
+	if _, err := starlight.Eval([]byte(`fn(m)`), globals, nil); err != nil {
+		t.Fatalf("in-range value should convert, got %v", err)
+	}
+	if got != 100 {
+		t.Fatalf("expected 100, got %d", got)
+	}
+}

--- a/convert/conv.go
+++ b/convert/conv.go
@@ -937,7 +937,9 @@ func convertSlice(val reflect.Value, argT reflect.Type) (reflect.Value, error) {
 				return reflect.Value{}, fmt.Errorf("slice element %d: %v", i, err)
 			}
 			newSlice.Index(i).Set(cv)
-		} else if elem.Elem().Type().ConvertibleTo(argElem) {
+		} else if (elem.Kind() == reflect.Interface || elem.Kind() == reflect.Ptr) && elem.Elem().Type().ConvertibleTo(argElem) {
+			// only unwrap interface/pointer elements; elem.Elem() panics on a
+			// concrete-kind element (e.g. an int8 from a wrapped []int8)
 			cv, err := checkedConvert(elem.Elem(), argElem)
 			if err != nil {
 				return reflect.Value{}, fmt.Errorf("slice element %d: %v", i, err)
@@ -998,50 +1000,18 @@ func convertElemValue(val reflect.Value, targetType reflect.Type) (reflect.Value
 				// reached when a host passes a custom starlark.Value inside a
 				// collection argument (e.g. map[string]interface{}{"k":
 				// myStarlarkValue}) to a typed Go parameter: FromValue leaves
-				// such values as-is, so we unwrap and re-narrow here
-				goVal := FromValue(sv)
-				goVal = convertNumericTypes(goVal, targetType)
-				if reflect.TypeOf(goVal) != targetType {
-					return reflect.Value{}, fmt.Errorf("expected type %v got %v", targetType, reflect.TypeOf(goVal))
+				// such values as-is, so we unwrap and re-narrow here. Route
+				// through checkedConvert so out-of-range narrowing errors
+				// instead of silently wrapping around.
+				gv := reflect.ValueOf(FromValue(sv))
+				if !gv.IsValid() {
+					return reflect.Value{}, fmt.Errorf("nil value cannot be converted to type %v", targetType)
 				}
-				return reflect.ValueOf(goVal), nil
+				return checkedConvert(gv, targetType)
 			}
 		}
 	}
 	return reflect.Value{}, fmt.Errorf("expected type %v got %v", targetType, val.Type())
-}
-
-func convertNumericTypes(value interface{}, targetType reflect.Type) interface{} {
-	// If the value is an integer, convert it to the appropriate integer type.
-	switch st := value.(type) {
-	case int64:
-		switch targetType.Kind() {
-		case reflect.Int:
-			return int(st)
-		case reflect.Int32:
-			return int32(st)
-		case reflect.Int16:
-			return int16(st)
-		case reflect.Int8:
-			return int8(st)
-		case reflect.Uint:
-			return uint(st)
-		case reflect.Uint64:
-			return uint64(st)
-		case reflect.Uint32:
-			return uint32(st)
-		case reflect.Uint16:
-			return uint16(st)
-		case reflect.Uint8:
-			return uint8(st)
-		}
-	// If the value is a float, convert it to the appropriate float type.
-	case float64:
-		if targetType.Kind() == reflect.Float32 {
-			return float32(st)
-		}
-	}
-	return value
 }
 
 // tryConv tries to convert starlark.Value v to Go t if v is not assignable to t.


### PR DESCRIPTION
## Two gaps from the type-coverage audit (H4/H5)

**H4 — internal panic on a concrete-kind element.** `convertSlice`'s third branch called `elem.Elem()` unconditionally. `Elem()` panics on a concrete (non-pointer, non-interface) element — e.g. an `int8` from a wrapped `[]int8` passed to a func whose parameter element type it is neither assignable nor convertible to. The panic was recovered into a confusing `reflect: call of reflect.Value.Elem on int8 Value` error. Guard the branch to interface/pointer kinds (as `convertElemValue` already does), so mismatches reach the clean `expected slice element type` error.

**H5 — silent integer wrap.** `convertElemValue`'s `starlark.Value` branch used the unchecked `convertNumericTypes`, so an out-of-range narrowing wrapped silently (`1000` → `int8(-24)`). Route it through `checkedConvert` so it errors like every other checked conversion. `convertNumericTypes` had no other caller and is removed.

## Tests

`convert/collection_elem_test.go`: a wrapped `[]int8` into an incompatible slice param yields a clean error (no `reflect:` leak); a raw `starlark.Int` map element overflowing `int8` errors, an in-range one converts, and a `None` element hits the nil-guard. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)