### PR TITLE
fix: GoInterface nil-pointer conversions and nilable Truth

### DIFF
--- a/convert/gointerface_nil_test.go
+++ b/convert/gointerface_nil_test.go
@@ -1,0 +1,28 @@
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/1set/starlight/convert"
+)
+
+type methodInt int
+
+func (m methodInt) Marker() {}
+
+// TestGoInterfaceNilPointerConversions: ToInt/ToBool/ToUint dereferenced a
+// nil pointer to a zero reflect.Value, then formatted the error with
+// v.Interface() — which panics on a zero Value. They must return a clean
+// error (like ToString/ToFloat, which use the reflect.Value directly).
+func TestGoInterfaceNilPointerConversions(t *testing.T) {
+	g := convert.MakeGoInterface((*methodInt)(nil))
+	if _, err := g.ToInt(); err == nil {
+		t.Fatal("ToInt on a nil typed pointer should error, not panic")
+	}
+	if _, err := g.ToBool(); err == nil {
+		t.Fatal("ToBool on a nil typed pointer should error, not panic")
+	}
+	if _, err := g.ToUint(); err == nil {
+		t.Fatal("ToUint on a nil typed pointer should error, not panic")
+	}
+}

--- a/convert/interface.go
+++ b/convert/interface.go
@@ -136,8 +136,11 @@ func (g *GoInterface) Truth() starlark.Bool {
 		return g.v.Float() != 0
 	case reflect.String:
 		return g.v.String() != ""
+	case reflect.Chan, reflect.Map, reflect.Func, reflect.Slice, reflect.Interface:
+		// nilable kinds: a nil value is falsy, like the Ptr case above
+		return starlark.Bool(!g.v.IsNil())
 	}
-	// otherwise... I dunno man, sure.
+	// otherwise: assume truthy (e.g. structs, arrays, complex)
 	return true
 }
 
@@ -162,7 +165,7 @@ func (g *GoInterface) ToInt() (int64, error) {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return v.Int(), nil
 	}
-	return 0, fmt.Errorf("can't convert type %T to int64", v.Interface())
+	return 0, fmt.Errorf("can't convert type %s to int64", g.v.Type())
 }
 
 // ToBool converts the interface value into a starlark bool.  This will fail if
@@ -176,7 +179,7 @@ func (g *GoInterface) ToBool() (bool, error) {
 	case reflect.Bool:
 		return v.Bool(), nil
 	}
-	return false, fmt.Errorf("can't convert type %T to bool", v.Interface())
+	return false, fmt.Errorf("can't convert type %s to bool", g.v.Type())
 }
 
 // ToUint converts the interface value into a starlark int.  This will fail if
@@ -190,7 +193,7 @@ func (g *GoInterface) ToUint() (uint64, error) {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		return v.Uint(), nil
 	}
-	return 0, fmt.Errorf("can't convert type %T to uint64", v.Interface())
+	return 0, fmt.Errorf("can't convert type %s to uint64", g.v.Type())
 }
 
 // ToString converts the interface value into a starlark string.  This will fail if

--- a/convert/truth_nilable_test.go
+++ b/convert/truth_nilable_test.go
@@ -1,0 +1,30 @@
+package convert
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestGoInterfaceTruthNilable: Truth returned a blanket true for kinds it
+// didn't enumerate, so a nil chan/map/func/slice wrapped in a GoInterface
+// reported truthy. Nilable kinds should reflect their nil-ness.
+func TestGoInterfaceTruthNilable(t *testing.T) {
+	cases := []struct {
+		v    interface{}
+		want bool
+	}{
+		{(chan int)(nil), false},
+		{make(chan int), true},
+		{map[string]int(nil), false},
+		{map[string]int{"a": 1}, true},
+		{([]int)(nil), false},
+		{[]int{1}, true},
+		{(func())(nil), false},
+	}
+	for _, c := range cases {
+		gi := &GoInterface{v: reflect.ValueOf(c.v)}
+		if got := bool(gi.Truth()); got != c.want {
+			t.Errorf("Truth(%T nil=%v) = %v, want %v", c.v, reflect.ValueOf(c.v).IsNil(), got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Two interface.go gaps from the type-coverage audit

**H6 (high) — nil-pointer conversion panic.** `ToInt`/`ToBool`/`ToUint` dereference a pointer, then format their error with `v.Interface()`. For a **nil typed pointer** (`*myInt` etc.) the deref yields a zero `reflect.Value` and `v.Interface()` panics (`reflect: call of reflect.Value.Interface on zero Value`). Format with `g.v.Type()` instead — always valid, nil-safe, and more informative — matching how `ToString`/`ToFloat` already do it.

**L5 (low) — blanket-truthy Truth.** `Truth` returned `true` for any kind it didn't enumerate, so a nil chan/map/func/slice wrapped in a `GoInterface` reported truthy. Nilable kinds now reflect their nil-ness, like the existing `Ptr` case.

## Tests

`gointerface_nil_test.go`: ToInt/ToBool/ToUint on a nil typed pointer error instead of panicking. `truth_nilable_test.go` (white-box): nil chan/map/slice/func are falsy, non-nil ones truthy. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)