### PR TITLE
fix: uintptr conversion targets get the numeric guards

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -1105,7 +1105,7 @@ func checkedConvert(val reflect.Value, t reflect.Type) (reflect.Value, error) {
 				return reflect.Value{}, fmt.Errorf("value %v out of range for type %s", f, t)
 			}
 		}
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		switch val.Kind() {
 		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 			i := val.Int()

--- a/convert/uintptr_test.go
+++ b/convert/uintptr_test.go
@@ -1,0 +1,34 @@
+package convert_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/1set/starlight"
+)
+
+// TestCheckedConvertUintptr: checkedConvert had no reflect.Uintptr target
+// case, so a numeric Starlark value converted to a uintptr parameter
+// skipped the negative/overflow/truncation guards and wrapped silently.
+func TestCheckedConvertUintptr(t *testing.T) {
+	var got uintptr
+	globals := map[string]interface{}{
+		"fn": func(u uintptr) { got = u },
+	}
+	// negative -> error (a uintptr cannot be negative)
+	if _, err := starlight.Eval([]byte(`fn(-1)`), globals, nil); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("expected out-of-range error for fn(-1), got %v (got=%d)", err, got)
+	}
+	// fractional -> truncation error
+	if _, err := starlight.Eval([]byte(`fn(3.9)`), globals, nil); err == nil || !strings.Contains(err.Error(), "truncated") {
+		t.Fatalf("expected truncation error for fn(3.9), got %v", err)
+	}
+	// in-range value still works
+	got = 0
+	if _, err := starlight.Eval([]byte(`fn(42)`), globals, nil); err != nil {
+		t.Fatalf("fn(42) should work, got %v", err)
+	}
+	if got != 42 {
+		t.Fatalf("expected 42, got %d", got)
+	}
+}


### PR DESCRIPTION
## Problem (type-coverage audit, gaps M5/M6)

`checkedConvert`'s target-kind switch covered `Uint`/`Uint8..64` but not `Uintptr`. A numeric Starlark value converted to a `uintptr` parameter (a Go func or field of type `uintptr`) was `ConvertibleTo` but skipped the negative/overflow/truncation checks, so it wrapped silently — e.g. `-1` became a huge `uintptr`.

## Fix

Add `reflect.Uintptr` to the unsigned target case. `uintptr` is an unsigned machine-width integer, so the existing `OverflowUint` guard bodies apply unchanged.

## Tests

`uintptr_test.go`: `fn(-1)` and `fn(3.9)` into a `func(uintptr)` error; `fn(42)` converts. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)