### PR TITLE
fix: typed-nil values no longer panic the host

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -35,7 +35,7 @@ func (e *PanicError) Error() string {
 // Any starlark.Value is passed through as-is.
 func ToValue(v interface{}) (starlark.Value, error) {
 	if val, ok := v.(starlark.Value); ok {
-		return val, nil
+		return passThroughOrNone(val), nil
 	}
 	return toValue(reflect.ValueOf(v), emptyStr)
 }
@@ -44,9 +44,19 @@ func ToValue(v interface{}) (starlark.Value, error) {
 // It works like ToValue, but also accepts a tag name to use for all nested struct fields.
 func ToValueWithTag(v interface{}, tagName string) (starlark.Value, error) {
 	if val, ok := v.(starlark.Value); ok {
-		return val, nil
+		return passThroughOrNone(val), nil
 	}
 	return toValue(reflect.ValueOf(v), tagName)
+}
+
+// passThroughOrNone returns v unchanged, except a typed-nil pointer that
+// merely satisfies the starlark.Value interface becomes None: returning it
+// as-is would panic later when the interpreter dereferenced it.
+func passThroughOrNone(v starlark.Value) starlark.Value {
+	if rv := reflect.ValueOf(v); rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return starlark.None
+	}
+	return v
 }
 
 func hasMethods(val reflect.Value) bool {
@@ -67,9 +77,10 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 	}()
 
 	if val.IsValid() {
-		if _, ok := val.Interface().(starlark.Value); ok {
-			// let Starlark values pass through, no conversion needed
-			return val.Interface().(starlark.Value), nil
+		if sv, ok := val.Interface().(starlark.Value); ok {
+			// let Starlark values pass through, no conversion needed (a
+			// typed-nil pointer satisfying the interface becomes None)
+			return passThroughOrNone(sv), nil
 		}
 		// time.Duration maps to the standard Starlark time.duration, the
 		// mirror of the FromValue case below; without this it would be
@@ -849,8 +860,17 @@ func makeOut(out []reflect.Value, tagName string) (starlark.Value, error) {
 	if last.Type() == errType || last.Type().Implements(errType) {
 		isNil := false
 		switch last.Kind() {
-		case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
 			isNil = last.IsNil()
+		case reflect.Interface:
+			// a nil interface is "no error"; so is a non-nil interface that
+			// boxes a typed-nil pointer (the common func() (T, error) {
+			// return v, nilPtr } idiom) — peel one layer to detect it
+			if last.IsNil() {
+				isNil = true
+			} else if e := last.Elem(); e.Kind() == reflect.Ptr || e.Kind() == reflect.Map || e.Kind() == reflect.Slice || e.Kind() == reflect.Func || e.Kind() == reflect.Chan {
+				isNil = e.IsNil()
+			}
 		}
 		if !isNil {
 			err = last.Interface().(error)

--- a/convert/typed_nil_test.go
+++ b/convert/typed_nil_test.go
@@ -1,0 +1,55 @@
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// TestToValueTypedNilStarlarkPointer: a typed-nil pointer that satisfies the
+// starlark.Value interface (e.g. (*starlark.List)(nil)) passed the assertion
+// in ToValue and was returned as-is, panicking later when the interpreter
+// dereferenced it. It must become None, like other nil-ish inputs.
+func TestToValueTypedNilStarlarkPointer(t *testing.T) {
+	var l *starlark.List
+	var d *starlark.Dict
+	for _, v := range []interface{}{l, d} {
+		got, err := convert.ToValue(v)
+		if err != nil {
+			t.Fatalf("ToValue(%T) errored: %v", v, err)
+		}
+		if got != starlark.None {
+			t.Fatalf("ToValue(%T nil) = %v, want None", v, got)
+		}
+	}
+}
+
+type boxNilErr struct{}
+
+func (e *boxNilErr) Error() string { return "should-not-raise" }
+
+// TestMakeOutBoxedNilError: a func declaring (T, error) that returns a
+// typed-nil pointer boxed in the error interface (a common Go idiom) must
+// not raise — the boxed nil is "no error".
+func TestMakeOutBoxedNilError(t *testing.T) {
+	globals := map[string]interface{}{
+		"fn": func() (int, error) {
+			var e *boxNilErr // typed nil
+			return 42, e
+		},
+	}
+	res, err := starlight.Eval([]byte(`x = fn()`), globals, nil)
+	if err != nil {
+		t.Fatalf("boxed typed-nil error must not raise, got %v", err)
+	}
+	if res["x"] != int64(42) {
+		t.Fatalf("expected 42, got %v", res["x"])
+	}
+	// a real error still raises
+	globals["fn2"] = func() (int, error) { return 0, &boxNilErr{} }
+	if _, err := starlight.Eval([]byte(`x = fn2()`), globals, nil); err == nil {
+		t.Fatal("a non-nil error should still raise")
+	}
+}

--- a/eval_nil_reader_test.go
+++ b/eval_nil_reader_test.go
@@ -1,0 +1,17 @@
+package starlight
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestEvalTypedNilReader: a typed-nil io.Reader passed as src (a host
+// mistake) reached the interpreter's source reader and panicked. It must
+// return a clean error instead.
+func TestEvalTypedNilReader(t *testing.T) {
+	var r *bytes.Buffer // typed-nil, but satisfies io.Reader
+	_, err := Eval(r, nil, nil)
+	if err == nil {
+		t.Fatal("expected an error for a typed-nil reader, not a panic")
+	}
+}

--- a/starlight.go
+++ b/starlight.go
@@ -38,12 +38,24 @@ func Eval(src interface{}, globals map[string]interface{}, load LoadFunc) (map[s
 	if ok {
 		dict, err = starlark.ExecFileOptions(dialectOptions, thread, filename, nil, dict)
 	} else {
-		dict, err = starlark.ExecFileOptions(dialectOptions, thread, "eval.sky", src, dict)
+		dict, err = execNonFileSource(thread, src, dict)
 	}
 	if err != nil {
 		return nil, err
 	}
 	return convert.FromStringDict(dict), nil
+}
+
+// execNonFileSource runs a non-filename source ([]byte or io.Reader). It
+// recovers panics from the interpreter's source reader — e.g. a host passing
+// a typed-nil io.Reader — and returns them as a clean error.
+func execNonFileSource(thread *starlark.Thread, src interface{}, dict starlark.StringDict) (out starlark.StringDict, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			out, err = nil, fmt.Errorf("starlight: cannot read source: %v", r)
+		}
+	}()
+	return starlark.ExecFileOptions(dialectOptions, thread, "eval.sky", src, dict)
 }
 
 // Cache is a cache of scripts to avoid re-reading files and re-parsing them.


### PR DESCRIPTION
## Three typed-nil gaps from the type-coverage audit (M1/M4/L6)

- **M1** — a typed-nil pointer that *satisfies* `starlark.Value` (e.g. `(*starlark.List)(nil)`) passed the pass-through assertion in `ToValue`/`ToValueWithTag`/`toValue` and was returned as-is, panicking later when the interpreter dereferenced it. It now becomes `None` (`passThroughOrNone`), mirroring the nil-interface rule.
- **M4** — a func declaring `(T, error)` that returns a typed-nil pointer **boxed in the error interface** (the common `return v, nilPtr` idiom) spuriously raised, because the boxed interface is non-nil. `makeOut` now peels one layer to detect a boxed typed-nil and treats it as *no error*. A genuinely non-nil error still raises.
- **L6** — a typed-nil `io.Reader` passed as `Eval`'s source panicked inside the interpreter's source reader; `execNonFileSource` recovers it into a clean error.

## Tests

`convert/typed_nil_test.go` (M1, M4) + `eval_nil_reader_test.go` (L6). Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)