### PR TITLE
fix: deterministic order for pointer and pointer-bearing map keys

### DIFF
--- a/convert/common.go
+++ b/convert/common.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -131,6 +132,11 @@ func decorateKey(v reflect.Value) sortableKey {
 		}
 		u = u.Elem()
 	}
+	// unwrap pointers so a *scalar key classifies and sorts by its pointee
+	// value, not by its (run-varying) address
+	for u.Kind() == reflect.Ptr && !u.IsNil() {
+		u = u.Elem()
+	}
 	switch u.Kind() {
 	case reflect.Bool:
 		k.rank = 1
@@ -150,10 +156,67 @@ func decorateKey(v reflect.Value) sortableKey {
 		k.rank = 5
 		k.s = u.String()
 	default:
+		// composite or pointer-bearing keys: render address-free so equal
+		// values produce equal sort keys (fmt.Sprint would leak addresses)
 		k.rank = 6
-		k.s = fmt.Sprint(u.Interface())
+		k.s = stableKeyString(u)
 	}
 	return k
+}
+
+// stableKeyString renders a map key to an address-free, value-stable string
+// for deterministic sorting. It reads values through reflect accessors (so
+// it works on unexported struct fields) and renders pointers by their
+// pointee, never by address. Slices/maps/funcs cannot be map keys, so they
+// do not appear here; channels (comparable by identity) render as a kind
+// marker.
+func stableKeyString(v reflect.Value) string {
+	var b strings.Builder
+	writeStableKey(&b, v)
+	return b.String()
+}
+
+func writeStableKey(b *strings.Builder, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Bool:
+		fmt.Fprintf(b, "%t", v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		fmt.Fprintf(b, "%d", v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		fmt.Fprintf(b, "%d", v.Uint())
+	case reflect.Float32, reflect.Float64:
+		fmt.Fprintf(b, "%g", v.Float())
+	case reflect.Complex64, reflect.Complex128:
+		fmt.Fprintf(b, "%v", v.Complex())
+	case reflect.String:
+		b.WriteString(v.String())
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			b.WriteString("<nil>")
+		} else {
+			writeStableKey(b, v.Elem())
+		}
+	case reflect.Struct:
+		b.WriteByte('{')
+		for i := 0; i < v.NumField(); i++ {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			writeStableKey(b, v.Field(i))
+		}
+		b.WriteByte('}')
+	case reflect.Array:
+		b.WriteByte('[')
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				b.WriteByte(' ')
+			}
+			writeStableKey(b, v.Index(i))
+		}
+		b.WriteByte(']')
+	default:
+		fmt.Fprintf(b, "<%s>", v.Kind())
+	}
 }
 
 // sortableKeyLess is the strict weak ordering used by sortedMapKeys. Keys

--- a/convert/decorate_key_test.go
+++ b/convert/decorate_key_test.go
@@ -1,0 +1,72 @@
+package convert_test
+
+import (
+	"testing"
+
+	"github.com/1set/starlight/convert"
+	"go.starlark.net/starlark"
+)
+
+// valueOrder materializes a wrapped Go map's VALUES in the deterministic
+// order sortedMapKeys imposes over its keys. Values are address-free, so a
+// stable value sequence proves a stable key order without depending on how
+// the keys themselves stringify.
+func valueOrder(m interface{}) []string {
+	g := convert.NewGoMap(m)
+	var out []string
+	for _, item := range g.Items() {
+		out = append(out, string(item[1].(starlark.String)))
+	}
+	return out
+}
+
+// TestPointerKeyDeterministic: a map[*int]V key is a pointer; decorateKey
+// classified it as rank-6 and sorted by fmt.Sprint of the ADDRESS, so the
+// order varied run to run. After unwrapping the pointer it sorts by pointee
+// value — stable across constructions (Go map iteration is randomized).
+func TestPointerKeyDeterministic(t *testing.T) {
+	mk := func() map[*int]string {
+		a, b, c := 3, 1, 2
+		return map[*int]string{&a: "a", &b: "b", &c: "c"}
+	}
+	var want []string
+	for run := 0; run < 30; run++ {
+		got := valueOrder(mk())
+		if run == 0 {
+			want = got
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: pointer-key order changed: %v vs %v", run, got, want)
+			}
+		}
+	}
+}
+
+// TestPointerBearingStructKeyDeterministic: a map[struct{P *int}]V key is a
+// struct containing a pointer; the rank-6 fmt.Sprint leaked the field's
+// address into the sort key. An address-free render keeps the order stable.
+func TestPointerBearingStructKeyDeterministic(t *testing.T) {
+	type key struct {
+		N int
+		P *int
+	}
+	mk := func() map[key]string {
+		x, y, z := 10, 20, 30
+		return map[key]string{{N: 3, P: &x}: "a", {N: 1, P: &y}: "b", {N: 2, P: &z}: "c"}
+	}
+	var want []string
+	for run := 0; run < 30; run++ {
+		got := valueOrder(mk())
+		if run == 0 {
+			want = got
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("run %d: struct-ptr-key order changed: %v vs %v", run, got, want)
+			}
+		}
+	}
+}

--- a/convert/stable_key_test.go
+++ b/convert/stable_key_test.go
@@ -1,0 +1,47 @@
+package convert
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestStableKeyString covers every kind branch of the address-free key
+// renderer and asserts equal values render equally (no addresses leak).
+func TestStableKeyString(t *testing.T) {
+	type inner struct {
+		B bool
+		F float64
+	}
+	type composite struct {
+		N int
+		U uint8
+		S string
+		P *int
+		C complex128
+		A [2]int
+		I inner
+	}
+	mk := func() composite {
+		x := 7
+		return composite{N: -3, U: 200, S: "k", P: &x, C: 1 + 2i, A: [2]int{4, 5}, I: inner{B: true, F: 1.5}}
+	}
+	a, b := mk(), mk() // equal values, different *int addresses
+	sa := stableKeyString(reflect.ValueOf(a))
+	sb := stableKeyString(reflect.ValueOf(b))
+	if sa != sb {
+		t.Fatalf("equal values must render equally:\n a=%s\n b=%s", sa, sb)
+	}
+	for _, want := range []string{"-3", "200", "k", "7", "true", "1.5", "[4 5]"} {
+		if !strings.Contains(sa, want) {
+			t.Errorf("rendered key %q missing %q", sa, want)
+		}
+	}
+	// nil pointer and channel branches
+	if got := stableKeyString(reflect.ValueOf((*int)(nil))); got != "<nil>" {
+		t.Errorf("nil ptr -> %q, want <nil>", got)
+	}
+	if got := stableKeyString(reflect.ValueOf(make(chan int))); got != "<chan>" {
+		t.Errorf("chan -> %q, want <chan>", got)
+	}
+}


### PR DESCRIPTION
## Problem (type-coverage audit, gaps M7/L2)

`decorateKey` builds the sort key for deterministic map ordering. It classified a **pointer key** (`map[*int]V`) as rank-6 and sorted it by `fmt.Sprint` of its **address**, and rendered a **pointer-bearing struct/array key** the same way. Both produce run-varying order, breaking the determinism guarantee (SLT-01).

## Fix

- Unwrap top-level pointers, so a `*scalar` key classifies and sorts by its pointee value.
- Render composite / pointer-bearing rank-6 keys with a new `stableKeyString`: address-free and value-stable, reading values through reflect accessors (so it works on unexported struct fields) and rendering pointers by their pointee. Slices/maps/funcs can't be Go map keys; channels (comparable by identity) render as a kind marker.

## Tests

`convert/decorate_key_test.go`: `map[*int]V` and `map[struct{N int; P *int}]V` keys produce a stable iteration order across 30 reconstructions (Go map iteration is randomized), compared via address-free values. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)