### PR TITLE
fix: *time.Time maps to Starlark time; NewStruct nil panic message

### DIFF
--- a/convert/conv.go
+++ b/convert/conv.go
@@ -146,6 +146,12 @@ func toValue(val reflect.Value, tagName string) (result starlark.Value, err erro
 		}
 		return &GoSlice{v: arrayToSlice(val), tag: tagName}, nil
 	case reflect.Struct:
+		// a *time.Time reaches here still as a pointer (the deref switch
+		// above skips struct pointers, to preserve *struct -> *GoStruct);
+		// deref ONLY *time.Time so it hits the time special case below
+		if val.Kind() == reflect.Ptr && !val.IsNil() && val.Elem().Type() == reflect.TypeOf(time.Time{}) {
+			val = val.Elem()
+		}
 		// handle special case from standard starlark lib
 		switch val.Type() {
 		case reflect.TypeOf(time.Time{}):

--- a/convert/low_misc_test.go
+++ b/convert/low_misc_test.go
@@ -1,0 +1,62 @@
+package convert_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/1set/starlight"
+	"github.com/1set/starlight/convert"
+	startime "go.starlark.net/lib/time"
+)
+
+// TestPointerToTimeTime: a *time.Time reached the struct case still as a
+// pointer and was wrapped as a GoStruct instead of the Starlark time type.
+func TestPointerToTimeTime(t *testing.T) {
+	now := time.Date(2026, 6, 12, 1, 2, 3, 0, time.UTC)
+	v, err := convert.ToValue(&now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := v.(startime.Time); !ok {
+		t.Fatalf("expected startime.Time for *time.Time, got %T", v)
+	}
+	globals := map[string]interface{}{
+		"assert": &assert{t: t},
+		"t":      &now,
+	}
+	if _, err := starlight.Eval([]byte(`
+assert.Eq(type(t), "time.time")
+assert.Eq(t.year, 2026)
+`), globals, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestNewStructNilMessage: NewStruct/NewStructWithTag formatted their panic
+// with val.Interface(), which panics again on a nil (Invalid) arg. The panic
+// must carry a clean "<nil>".
+func TestNewStructNilMessage(t *testing.T) {
+	for _, fn := range []func(){
+		func() { convert.NewStruct(nil) },
+		func() { convert.NewStructWithTag(nil, "tag") },
+	} {
+		func() {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatal("expected panic for nil arg")
+				}
+				msg := fmt.Sprint(r)
+				if strings.Contains(msg, "zero Value") {
+					t.Fatalf("panic-message formatting itself panicked: %v", r)
+				}
+				if !strings.Contains(msg, "<nil>") {
+					t.Fatalf("expected '<nil>' in panic, got %v", r)
+				}
+			}()
+			fn()
+		}()
+	}
+}

--- a/convert/struct.go
+++ b/convert/struct.go
@@ -21,7 +21,7 @@ func NewStruct(strct interface{}) *GoStruct {
 	if val.Kind() == reflect.Struct || (val.Kind() == reflect.Ptr && val.Elem().Kind() == reflect.Struct) {
 		return &GoStruct{v: val}
 	}
-	panic(fmt.Errorf("value must be a struct or pointer to a struct, but was %T", val.Interface()))
+	panic(fmt.Errorf("value must be a struct or pointer to a struct, but was %T", strct))
 }
 
 // NewStructWithTag makes a new Starlark-compatible Struct from the given struct or pointer to struct,
@@ -35,7 +35,7 @@ func NewStructWithTag(strct interface{}, tagName string) *GoStruct {
 		}
 		return &GoStruct{v: val, tag: tagName}
 	}
-	panic(fmt.Errorf("value must be a struct or pointer to a struct, but was %T", val.Interface()))
+	panic(fmt.Errorf("value must be a struct or pointer to a struct, but was %T", strct))
 }
 
 // GoStruct is a wrapper around a Go struct to let it be manipulated by Starlark scripts.


### PR DESCRIPTION
## Two low-severity gaps from the type-coverage audit (L1, L4)

- **L1** — a `*time.Time` reached `toValue`'s struct case still as a pointer (the pre-switch deref skips struct pointers, to preserve the documented `*struct → *GoStruct` contract), so it was wrapped as a `GoStruct` instead of the Starlark `time` type. Deref `*time.Time` **specifically** (only that type) so it hits the existing time special case.
- **L4** — `NewStruct`/`NewStructWithTag` formatted their "not a struct" panic with `val.Interface()`, which panics *again* on a nil (Invalid) arg and masks the real message. Format the original argument instead (nil-safe, prints `<nil>`).

**L3** (the `toInt` int64→int truncation) is intentionally **not** changed: it is reachable only on 32-bit GOARCH, which this module's go1.19 floor does not target and CI does not exercise — a guard would be a permanently uncovered branch. It is documented in the type-detection checklist instead.

## Tests

`convert/low_misc_test.go`: `*time.Time` maps to Starlark time with time semantics; `NewStruct(nil)`/`NewStructWithTag(nil, …)` panic with a clean `<nil>` message (not a secondary reflect panic). Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)