### PR TITLE
test: golden end-to-end .star scripts + downstream-compat docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,28 @@ docker run --rm -v "$PWD":/src -v "$HOME/go/pkg/mod":/go/pkg/mod -w /src golang:
 
 CI (`.github/workflows/build.yml`): Go `1.19.x`/`1.25.x` × ubuntu-22.04 / macos-14 / windows-2022, plus CodeQL and the Codecov/Codacy coverage gate. The gate is the `codecov/project`+`codecov/patch` commit statuses, not the upload step (its `continue-on-error` only tolerates upload outages).
 
+## Downstream compatibility — a release gate
+
+starlight is the L1 foundation; `starlet` (via `dataconv`), `starbox`, and the `starpkg/*` modules all depend on it. A change can be locally green yet break a consumer. **Before tagging a release, run the two-leg matrix** — for each downstream (at least `starlet`, then `starbox` / `starpkg/base` / `starpkg/sqlite`):
+
+```bash
+# clone the downstream fresh to /tmp, then:
+#  baseline leg — its existing pins:
+docker run --rm -v <dst>:/src -v $HOME/go/pkg/mod:/go/pkg/mod -w /src golang:1.19 sh -c 'go build ./... && go test ./...'
+#  upgrade leg — point it at this starlight and re-tidy:
+( cd <dst> && go mod edit -replace github.com/1set/starlight=<this-repo> )
+docker run --rm -v <dst>:/src -v <this-repo>:/starlight-new -v $HOME/go/pkg/mod:/go/pkg/mod -w /src golang:1.19 \
+  sh -c 'go mod tidy && go build ./... && go test ./...'
+```
+
+Only failures that appear in the **upgrade leg but not the baseline** are regressions. Known pre-existing (not regressions): `starlet` `lib/file`/`lib/path` (need `/etc/sudoers` / a permission barrier absent under Docker-root); `starcli` build (goldmark needs go1.22). The replace also bumps `go.starlark.net` transitively via MVS — L0-caused breaks count too, and predict what the downstream's own pin-upgrade will face. `dataconv`/`dataconv/types` are the most load-bearing consumers — they must stay green.
+
+The `.star` module-test corpus lives at `starpkg/test/` (run via each module's harness, not from here).
+
+## Golden end-to-end tests
+
+`testdata/golden/*.star` are classic scripts run through the real interpreter (see `starlight_features_test.go` section 3): they exercise deterministic order, empty-interface unwrapping, tuple/big-int keys, `str()` safety, and the compiled dialect. Add a script there (and a `checks` map) when a fix has script-observable behavior — it's the cheapest end-to-end regression layer.
+
 ## Architecture
 
 Everything is the `convert` package's bidirectional bridge:

--- a/starlight_features_test.go
+++ b/starlight_features_test.go
@@ -12,6 +12,8 @@ import (
 //   1. Dialect: no global resolve.* mutation on import; set/lambda/float/
 //      bitwise/nested-def work; cache compile paths
 //   2. WithGlobals constructor (load()-module globals)
+//   3. Golden end-to-end .star scripts (testdata/golden/*.star) that exercise
+//      the conversion behaviors through the real interpreter
 
 // Importing starlight (and, transitively, convert) must not mutate any
 // process-global state: the dialect is passed explicitly to every
@@ -144,5 +146,85 @@ func TestWithGlobalsNoDirs(t *testing.T) {
 func TestWithGlobalsConvertError(t *testing.T) {
 	if _, err := WithGlobals(map[string]interface{}{"bad": make(chan int)}, t.TempDir()); err == nil {
 		t.Fatal("expected conversion error for an unsupported global type")
+	}
+}
+
+// ---- Section 3: golden end-to-end .star scripts ----
+
+// runGolden reads testdata/golden/<file>.star, runs it through Eval with the
+// given globals, and returns the resulting global namespace. A script error
+// fails the test (the scripts self-check via their out_* globals, asserted
+// by the caller).
+func runGolden(t *testing.T, file string, globals map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", "golden", file))
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Eval(src, globals, nil)
+	if err != nil {
+		t.Fatalf("%s: %v", file, err)
+	}
+	return res
+}
+
+// TestGoldenConversion runs testdata/golden/conversion.star against real Go
+// values and asserts the conversion behaviors hold end-to-end (deterministic
+// order, empty-interface unwrapping, tuple/big-int keys, str safety).
+func TestGoldenConversion(t *testing.T) {
+	pairs := map[interface{}]interface{}{}
+	globals := map[string]interface{}{
+		"nums": map[string]int{"c": 3, "a": 1, "b": 2, "e": 5, "d": 4},
+		"mixed": map[string]interface{}{
+			"a": 1, "b": 2, "inner": map[string]interface{}{"x": 42},
+		},
+		"pairs": pairs,
+	}
+	// seed the wrapped map with a tuple key and a big-int key via a setup script
+	setup, err := Eval([]byte(`
+p[(1, "a")] = "tuple-value"
+p[1 << 70] = "bigint-value"
+`), map[string]interface{}{"p": pairs}, nil)
+	_ = setup
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	res := runGolden(t, "conversion.star", globals)
+	checks := map[string]interface{}{
+		"out_keys_sorted":     true,
+		"out_keys_match_iter": true,
+		"out_items_match":     true,
+		"out_sum":             int64(3),
+		"out_a_type":          "int",
+		"out_eq":              true,
+		"out_nested":          int64(42),
+		"out_tuple_key":       "tuple-value",
+		"out_bigint_key":      "bigint-value",
+		"out_str_ok":          true,
+	}
+	for k, want := range checks {
+		if res[k] != want {
+			t.Errorf("conversion.star %s = %#v, want %#v", k, res[k], want)
+		}
+	}
+}
+
+// TestGoldenDialect runs testdata/golden/dialect.star to confirm the compiled
+// dialect (set/lambda/float/bitwise/nested-def) works through the explicit
+// FileOptions, with no globals supplied.
+func TestGoldenDialect(t *testing.T) {
+	res := runGolden(t, "dialect.star", nil)
+	checks := map[string]interface{}{
+		"out_set_len": int64(3),
+		"out_lambda":  int64(42),
+		"out_float":   float64(3),
+		"out_bitwise": int64(2),
+		"out_nested":  int64(7),
+	}
+	for k, want := range checks {
+		if res[k] != want {
+			t.Errorf("dialect.star %s = %#v, want %#v", k, res[k], want)
+		}
 	}
 }

--- a/testdata/golden/conversion.star
+++ b/testdata/golden/conversion.star
@@ -1,0 +1,26 @@
+# Golden end-to-end test of starlight's Go<->Starlark conversion, run through
+# the real interpreter. Globals supplied by the Go runner:
+#   nums  : Go map[string]int
+#   mixed : Go map[string]interface{}  (JSON-shaped)
+#   pairs : Go map[interface{}]interface{} with tuple + big-int keys
+#
+# Each `out_*` global is asserted by the runner.
+
+# --- SLT-01 deterministic map order: keys() is sorted, stable, == iteration ---
+ks = nums.keys()
+out_keys_sorted = (ks == sorted(ks))
+out_keys_match_iter = (ks == [k for k in nums])
+out_items_match = ([nums[k] for k in ks] == [i[1] for i in nums.items()])
+
+# --- SLT-08 empty-interface unwrap: JSON-shaped values are native, usable ---
+out_sum = mixed["a"] + mixed["b"]          # ints unwrap -> arithmetic works
+out_a_type = type(mixed["a"])              # "int", not a wrapper
+out_eq = (mixed["a"] == 1)                 # comparison works
+out_nested = mixed["inner"]["x"] + 0       # nested dict usable
+
+# --- SLT-02 tuple key + SLT-17 big-int key round-trip through a wrapped map ---
+out_tuple_key = pairs[(1, "a")]
+out_bigint_key = pairs[1 << 70]
+
+# --- SLT-03 safety: str() of a (large) wrapped map never crashes the host ---
+out_str_ok = (len(str(nums)) > 0)

--- a/testdata/golden/dialect.star
+++ b/testdata/golden/dialect.star
@@ -1,0 +1,13 @@
+# Golden test that the compiled dialect (set + lambda + float + bitwise +
+# nested def) works through starlight's explicit FileOptions.
+s = set([3, 1, 2, 1])
+out_set_len = len(s)                       # 3 (dedup)
+out_lambda = (lambda x: x * 2)(21)         # 42
+out_float = 1.5 * 2                         # 3.0
+out_bitwise = 6 & 3                         # 2
+
+def outer():
+    def inner():
+        return 7
+    return inner()
+out_nested = outer()                       # 7


### PR DESCRIPTION
## What

- **`testdata/golden/{conversion,dialect}.star`** — classic scripts run through the real interpreter (`starlight_features_test.go` section 3, per the test-organization rule: a *section*, not new files). They exercise the headline conversion behaviors end-to-end: deterministic map order (keys == sorted == iteration), empty-interface unwrapping (JSON-shaped values native & usable), tuple + big-int map keys round-tripping, `str()` safety, and the compiled dialect (set/lambda/float/bitwise/nested-def). Scripts self-describe via `out_*` globals; the Go runner asserts a `checks` map. Cheapest layer to extend when a fix has script-observable behavior.
- **`CLAUDE.md`** — documents the **two-leg downstream compatibility matrix** as a release gate (baseline vs upgrade leg, Docker go1.19, regression = upgrade-leg-only, known pre-existing failures, MVS L0 bump), and the golden-test convention.

## Tests

`TestGoldenConversion` + `TestGoldenDialect` run the scripts and assert outputs. Full suite `-race`; Go 1.19 via Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)