### PR TITLE
fix: cache compiled programs by predeclared name set (SLT-17)

### DIFF
--- a/starlight.go
+++ b/starlight.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/1set/starlight/convert"
@@ -126,8 +128,9 @@ func (c *Cache) Run(filename string, globals map[string]interface{}) (map[string
 	if err != nil {
 		return nil, err
 	}
+	key := scriptCacheKey(filename, dict)
 	c.mu.Lock()
-	if p, ok := c.scripts[filename]; ok {
+	if p, ok := c.scripts[key]; ok {
 		c.mu.Unlock()
 		return run(p, globals, c.Load)
 	}
@@ -142,9 +145,27 @@ func (c *Cache) Run(filename string, globals map[string]interface{}) (map[string
 		return nil, err
 	}
 	c.mu.Lock()
-	c.scripts[filename] = p
+	c.scripts[key] = p
 	c.mu.Unlock()
 	return run(p, globals, c.Load)
+}
+
+// scriptCacheKey composes the key under which a compiled program is cached.
+// Compilation resolves each identifier as predeclared vs global via the
+// predeclared name set (dict.Has), so the same file compiled under a
+// different set of global names is a different program: keying on the
+// filename alone returned a stale program that failed at run time with
+// "internal error: predeclared variable X is uninitialized" — or silently
+// reused a program resolved under the wrong name set. The dialect is fixed
+// (dialectOptions) for every compile here, so only the filename and the
+// sorted predeclared names need to participate.
+func scriptCacheKey(filename string, dict starlark.StringDict) string {
+	names := make([]string, 0, len(dict))
+	for n := range dict {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return filename + "\x00" + strings.Join(names, "\x00")
 }
 
 // Load loads a module using the cache's configured directories.
@@ -178,6 +199,15 @@ func (c *Cache) Reset() {
 func (c *Cache) Forget(filename string) {
 	c.mu.Lock()
 	c.cache.remove(filename)
-	delete(c.scripts, filename)
+	// Run keys c.scripts by filename + predeclared name set (see
+	// scriptCacheKey), so a single file may have several entries — one per
+	// distinct global-name set it was run under. Every such key begins with
+	// "filename\x00"; drop them all.
+	prefix := filename + "\x00"
+	for k := range c.scripts {
+		if strings.HasPrefix(k, prefix) {
+			delete(c.scripts, k)
+		}
+	}
 	c.mu.Unlock()
 }

--- a/starlight_features_test.go
+++ b/starlight_features_test.go
@@ -3,6 +3,7 @@ package starlight
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +15,7 @@ import (
 //   2. WithGlobals constructor (load()-module globals)
 //   3. Golden end-to-end .star scripts (testdata/golden/*.star) that exercise
 //      the conversion behaviors through the real interpreter
+//   4. Cache-key isolation by predeclared name set
 
 // Importing starlight (and, transitively, convert) must not mutate any
 // process-global state: the dialect is passed explicitly to every
@@ -226,5 +228,52 @@ func TestGoldenDialect(t *testing.T) {
 		if res[k] != want {
 			t.Errorf("dialect.star %s = %#v, want %#v", k, res[k], want)
 		}
+	}
+}
+
+// ---- Section 4: cache-key isolation by predeclared name set ----
+
+// TestCachePredeclaredNameSet pins the compiled-program cache key to the
+// predeclared name set, not the filename alone. The same file run first with
+// a global and then without it must recompile cleanly instead of reusing a
+// program that resolved the name as predeclared — which failed at run time
+// with "internal error: predeclared variable x is uninitialized".
+func TestCachePredeclaredNameSet(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "p.star"), []byte("out = x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := New(dir)
+
+	res, err := c.Run("p.star", map[string]interface{}{"x": 1})
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	if res["out"] != int64(1) {
+		t.Fatalf("first run out = %v (%T), want 1", res["out"], res["out"])
+	}
+
+	// Same file, but x is no longer a predeclared name. The old filename-only
+	// key reused the stale program and failed with an internal error; now it
+	// recompiles and reports the honest resolve error.
+	_, err = c.Run("p.star", nil)
+	if err == nil {
+		t.Fatal("second run with no globals: expected an error, got nil")
+	}
+	if strings.Contains(err.Error(), "internal error") {
+		t.Fatalf("second run leaked a stale-program internal error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "undefined: x") {
+		t.Fatalf("second run error = %q, want an 'undefined: x' resolve error", err)
+	}
+
+	// Re-running with the global again must still work (its own cached
+	// program for that name set).
+	res, err = c.Run("p.star", map[string]interface{}{"x": 5})
+	if err != nil {
+		t.Fatalf("third run: %v", err)
+	}
+	if res["out"] != int64(5) {
+		t.Fatalf("third run out = %v, want 5", res["out"])
 	}
 }


### PR DESCRIPTION
## What

`Cache.Run` keyed its compiled-program cache (`c.scripts`) by **filename only**, but `SourceProgramOptions` resolves each identifier as predeclared vs global against the current predeclared name set (`dict.Has`). So running the same file under a different set of globals reused a **stale program**:

- first `Run("p.star", {"x":1})` compiles `out = x` with `x` predeclared → ok;
- then `Run("p.star", nil)` reuses that program and fails at run time with `internal error: predeclared variable x is uninitialized` (or, in the reverse direction, silently reuses a program resolved under the wrong name set).

This is the starlight twin of the issue already fixed in starlet's `exec.go` `getCacheKey`.

## Fix

Fold the sorted predeclared name set into the cache key (`scriptCacheKey`); the dialect is fixed (`dialectOptions`), so `filename + names` suffices. `Forget` now drops **every** key belonging to a filename (a file may have several entries, one per distinct global-name set).

## Test-first

`TestCachePredeclaredNameSet` reproduces the stale-program internal error before the fix and pins the corrected behavior (clean `undefined: x` resolve error; same-name-set runs still hit the cache).

## Verification

`go test -race -count=2 ./...`, `go vet`, `gofmt -l` clean, and the Docker `golang:1.19` race run all green.

Backlog: **SLT-17**