### PR TITLE
fix: confine Cache file lookups to the configured directories (SLT-18)

### DIFF
--- a/starlight.go
+++ b/starlight.go
@@ -177,7 +177,20 @@ func (c *Cache) readFile(filename string) ([]byte, error) {
 	var err error
 	var b []byte
 	for _, d := range c.dirs {
-		b, err = ioutil.ReadFile(filepath.Join(d, filename))
+		full := filepath.Join(d, filename)
+		// Containment: filepath.Join cleans embedded ".." segments, so a
+		// script-controlled name like "../secret.star" (Run and the load()
+		// path both reach here) can resolve above d and read a sibling or
+		// parent file. Skip any candidate that escapes d; a name that stays
+		// within a *different* configured dir is still served from that one,
+		// and only a name that escapes every dir falls through to not-found.
+		// This is defense in depth — confinement is not a guarantee of New()
+		// (real sandboxing belongs to the host layer), but the search scope
+		// should not silently reach outside the directories it was given.
+		if !withinDir(d, full) {
+			continue
+		}
+		b, err = ioutil.ReadFile(full)
 		if err == nil {
 			return b, nil
 		}
@@ -185,6 +198,17 @@ func (c *Cache) readFile(filename string) ([]byte, error) {
 	// guaranteed to have at least one directory, so there should be at least
 	// not found error here.
 	return nil, fmt.Errorf("cannot find file %q in any of the configured directories %q", filename, c.dirs)
+}
+
+// withinDir reports whether the cleaned path full is dir itself or lives
+// under it. A path that climbs out of dir via ".." (e.g. dir/../secret) is
+// rejected. Both paths are cleaned before comparison.
+func withinDir(dir, full string) bool {
+	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(full))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // Reset clears all cached scripts.

--- a/starlight_features_test.go
+++ b/starlight_features_test.go
@@ -15,7 +15,8 @@ import (
 //   2. WithGlobals constructor (load()-module globals)
 //   3. Golden end-to-end .star scripts (testdata/golden/*.star) that exercise
 //      the conversion behaviors through the real interpreter
-//   4. Cache-key isolation by predeclared name set
+//   4. Cache-key isolation by predeclared name set; readFile path
+//      containment
 
 // Importing starlight (and, transitively, convert) must not mutate any
 // process-global state: the dialect is passed explicitly to every
@@ -275,5 +276,75 @@ func TestCachePredeclaredNameSet(t *testing.T) {
 	}
 	if res["out"] != int64(5) {
 		t.Fatalf("third run out = %v, want 5", res["out"])
+	}
+}
+
+// TestCachePathContainment verifies Run and load() cannot read a file that
+// escapes every configured directory via "..". Confinement is not a promised
+// guarantee of New(), but the directory search must not silently reach a
+// parent or sibling file a script names.
+func TestCachePathContainment(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "secret.star"), []byte("leaked = 42\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scripts := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(filepath.Join(scripts, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scripts, "ok.star"), []byte("v = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scripts, "sub", "deep.star"), []byte("v = 2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scripts, "loader.star"),
+		[]byte("load(\"../secret.star\", \"leaked\")\ngot = leaked\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := New(scripts)
+
+	// Direct escape via Run must fail (not read the parent's secret.star).
+	if _, err := c.Run("../secret.star", nil); err == nil {
+		t.Fatal("Run('../secret.star') escaped the configured directory")
+	}
+	// Escape via a script's load() must fail too.
+	if _, err := c.Run("loader.star", nil); err == nil {
+		t.Fatal("load('../secret.star') escaped the configured directory")
+	}
+	// Legitimate in-tree access still works, including a subdirectory.
+	if res, err := c.Run("ok.star", nil); err != nil || res["v"] != int64(1) {
+		t.Fatalf("in-tree Run('ok.star') = %v, %v; want v=1", res, err)
+	}
+	if res, err := c.Run("sub/deep.star", nil); err != nil || res["v"] != int64(2) {
+		t.Fatalf("in-tree Run('sub/deep.star') = %v, %v; want v=2", res, err)
+	}
+}
+
+// TestCacheMultiDirSiblingAccess verifies that a "..":-bearing name escaping
+// one configured dir but landing inside another configured dir is still
+// served — only names escaping every dir are rejected.
+func TestCacheMultiDirSiblingAccess(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "a")
+	b := filepath.Join(root, "b")
+	if err := os.MkdirAll(a, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(b, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(b, "x.star"), []byte("v = 7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := New(a, b)
+	// "../b/x.star" escapes a but resolves within b, a configured dir.
+	res, err := c.Run("../b/x.star", nil)
+	if err != nil {
+		t.Fatalf("multi-dir sibling access: %v", err)
+	}
+	if res["v"] != int64(7) {
+		t.Fatalf("multi-dir sibling access v = %v, want 7", res["v"])
 	}
 }


### PR DESCRIPTION
## What

`Cache.readFile` joined a script-controlled name to each configured directory with no post-join containment check. `filepath.Join` cleans embedded `..` segments, so a name like `../secret.star` resolved **above** the configured directory and was read and executed. Both entry points reach this function: `Cache.Run` and, more importantly, `load()` — whose module strings are fully script-controlled, so an untrusted script could read any `.star`-parseable file the host process can reach.

(The absolute-path vector does *not* apply — `filepath.Join` neutralizes a leading `/`; only `..` traversal escapes.)

## Fix

`withinDir` rejects a candidate that climbs out of a directory via `..`. A name that escapes one configured dir but lands inside **another** configured dir is still served from that one; only a name escaping **every** dir falls through to not-found. In-tree and subdirectory access are unchanged.

Confinement is not a promised guarantee of `New()` (real sandboxing belongs to the host layer), so this is defense in depth rather than a fix to a stated invariant — but the directory search should not silently reach outside the directories it was given.

## Test-first

`TestCachePathContainment` (Run + `load()` escape both rejected; in-tree + subdir access preserved) and `TestCacheMultiDirSiblingAccess` (the escape-one-dir-but-within-another case) fail before the fix.

## Verification

`go test -race -count=2 ./...`, `go vet`, `gofmt -l` clean, Docker `golang:1.19` race run green.

Backlog: **SLT-18**