### PR TITLE
fix: pre-check element types in NewGoMap/NewGoSlice (SLT-19)

### DIFF
--- a/convert/map.go
+++ b/convert/map.go
@@ -31,11 +31,19 @@ var (
 )
 
 // NewGoMap wraps the given map m in a new GoMap.
-// This function will panic if m is nil or not a map.
+// This function will panic if m is nil or not a map, or if its key or element
+// type cannot be converted to Starlark (e.g. a chan or complex element) — the
+// same static check ToValue applies. Without it the wrapper constructs fine
+// but later panics inside Items/Keys/iteration, which cannot return an error;
+// rejecting at construction keeps those methods panic-free (invariant: methods
+// that can't return errors must never reach panic).
 func NewGoMap(m interface{}) *GoMap {
 	v := reflect.ValueOf(m)
 	if v.Kind() != reflect.Map {
 		panic(fmt.Errorf("NewGoMap expects a map, but got %T", m))
+	}
+	if err := checkCollectionElemTypesCached(v.Type()); err != nil {
+		panic(err)
 	}
 	return &GoMap{v: v}
 }

--- a/convert/robustness_test.go
+++ b/convert/robustness_test.go
@@ -150,6 +150,59 @@ func TestUnsupportedElemType(t *testing.T) {
 	}
 }
 
+// TestConstructorPrechecksElemTypes verifies the public NewGoMap/NewGoSlice
+// constructors run the same static element-type check ToValue runs, so an
+// unsupported element type panics at construction instead of building a
+// wrapper that panics later inside Items/Keys/Index/iteration — methods that
+// cannot return an error. This closes the gap where the safe ToValue path
+// rejected such collections but the direct constructors did not (invariant:
+// methods that can't return errors must never reach panic).
+func TestConstructorPrechecksElemTypes(t *testing.T) {
+	for _, m := range []interface{}{
+		map[string]chan int{"c": make(chan int)},
+		map[complex128]string{},
+		map[string][]chan int{},
+	} {
+		assertConstructPanics(t, fmt.Sprintf("NewGoMap(%T)", m), func() { convert.NewGoMap(m) })
+	}
+	for _, s := range []interface{}{
+		[]chan int{make(chan int)},
+		[]complex128{1i},
+		[2]chan int{},
+	} {
+		assertConstructPanics(t, fmt.Sprintf("NewGoSlice(%T)", s), func() { convert.NewGoSlice(s) })
+	}
+
+	// Supported element types (including interface{}, checked dynamically)
+	// must still construct without panicking.
+	assertNoConstructPanic(t, "NewGoMap supported", func() {
+		_ = convert.NewGoMap(map[string]interface{}{"a": 1})
+	})
+	assertNoConstructPanic(t, "NewGoSlice supported", func() {
+		_ = convert.NewGoSlice([]interface{}{1, "x"})
+	})
+}
+
+func assertConstructPanics(t *testing.T, what string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("%s: expected a panic for an unsupported element type, got none", what)
+		}
+	}()
+	fn()
+}
+
+func assertNoConstructPanic(t *testing.T, what string, fn func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("%s: unexpected panic: %v", what, r)
+		}
+	}()
+	fn()
+}
+
 // recursiveMapType is a genuinely recursive Go TYPE definition (its element
 // type is itself), unlike recMap above whose element type is interface{}.
 // It exercises the visited-set guard in checkCollectionElemTypes: without

--- a/convert/slice.go
+++ b/convert/slice.go
@@ -29,11 +29,19 @@ type GoSlice struct {
 
 // NewGoSlice wraps the given slice or array in a new GoSlice; arrays are
 // copied into a slice (see the GoSlice doc).
-// This function will panic if the argument is not a slice nor an array.
+// This function will panic if the argument is not a slice nor an array, or if
+// its element type cannot be converted to Starlark (e.g. a chan or complex
+// element) — the same static check ToValue applies. Without it the wrapper
+// constructs fine but later panics inside Index/iteration, which cannot return
+// an error; rejecting at construction keeps those methods panic-free
+// (invariant: methods that can't return errors must never reach panic).
 func NewGoSlice(slice interface{}) *GoSlice {
 	v := reflect.ValueOf(slice)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		panic(fmt.Errorf("NewGoSlice expects a slice or array, but got %T", slice))
+	}
+	if err := checkCollectionElemTypesCached(v.Type()); err != nil {
+		panic(err)
 	}
 	return &GoSlice{v: arrayToSlice(v)}
 }


### PR DESCRIPTION
## What

`ToValue` runs `checkCollectionElemTypes` before wrapping a map/slice, so an unsupported **static** element type (`chan`, `complex`, …) is rejected up front with a clean error. The public `NewGoMap` / `NewGoSlice` constructors skipped that check — they validated only the `Kind`, then built a wrapper that **panicked later** inside `Items`/`Keys`/`Index`/iteration, methods that cannot return an error.

This violated the repo invariant *"methods that can't return errors must never reach panic"* for any host that builds wrappers via the direct constructors (the `ToValue` path was already safe).

## Fix

Run the same `checkCollectionElemTypesCached` pre-check in both constructors and panic at construction if it fails — consistent with their existing documented panic-on-misuse contract (they already panic when given a non-map/non-slice), and moving the failure to a deterministic, host-controlled point *before* any script-reachable method call.

## Test-first

`TestConstructorPrechecksElemTypes` asserts the constructors panic for unsupported element types (map/slice/array with chan/complex elements) and still build supported ones (including dynamically-checked `interface{}`). Fails before the fix.

## Verification

`go test -race -count=2 ./...`, `go vet`, `gofmt -l` clean, Docker `golang:1.19` race run green.

Backlog: **SLT-19**